### PR TITLE
feat: déployer les pages publiques et le rattachement de score

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ BETTER_AUTH_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:5173
 FRONTEND_ORIGINS=http://localhost:5173
 VITE_API_URL=http://localhost:3000
+VITE_APP_TARGET=flipper
+
+# Score claim / QR code
+# local  = le backend courant écrit dans sa base locale.
+# remote = le backend local de la borne relaie les scores vers GLOBAL_API_URL.
+SCORE_CLAIM_MODE=local
+GLOBAL_API_URL=
+BORNE_TOKEN=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Déploiement VPS Production
 
-# Se lance quand le workflow "Tests & Coverage" se termine avec succès sur main
+# Se lance uniquement quand le workflow "Tests & Coverage" s'est terminé avec
+# succès. Cela évite de déployer un commit qui n'a pas passé les tests.
 on:
   workflow_run:
     workflows: ["Tests & Coverage"]
@@ -20,6 +21,10 @@ jobs:
     steps:
       - name: Récupération du code source
         uses: actions/checkout@v4
+        with:
+          # Sur un événement workflow_run, checkout utiliserait sinon la branche
+          # par défaut. On force donc le SHA exact qui vient de passer les tests.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Synchronisation des fichiers vers le VPS (rsync)
         uses: burnett01/rsync-deployments@7.0.1 # ne modif que les fichiers modifier dans le dépot, évite un "downtime"
@@ -39,13 +44,17 @@ jobs:
           script: |
             # Création du dossier s'il n'existe pas (sécurité au premier déploiement)
             cd ~/flipper-project
-          
-            # Injection des secrets
-            echo "MQTT_USERNAME=${{ secrets.MQTT_USERNAME }}" > .env
-            echo "MQTT_PASSWORD=${{ secrets.MQTT_PASSWORD }}" >> .env
-            
+
+            # Le .env du VPS est maintenu directement sur le serveur.
+            # La CI l'utilise mais ne l'écrase pas, afin d'éviter de perdre les
+            # secrets configurés manuellement pendant les tests de déploiement.
+            test -f .env || {
+              echo "Erreur: .env est manquant dans ~/flipper-project"
+              exit 1
+            }
+
             # Déploiement
-            sudo docker compose -f deploy/docker-compose.yml up -d --build
+            sudo docker compose --env-file .env -p flipper-project -f deploy/docker-compose.vps.yml up -d --build
             
             # Nettoyage des anciennes images inutilisées (libère de la place)
             sudo docker image prune -f
@@ -53,4 +62,4 @@ jobs:
             # Vérification de santé
             echo "Vérification du statut..."
             sleep 10
-            sudo docker compose -f deploy/docker-compose.yml ps
+            sudo docker compose --env-file .env -p flipper-project -f deploy/docker-compose.vps.yml ps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
       - "**"
 
 jobs:
-  test:
-    name: Tests unitaires & couverture
+  frontend:
+    name: Frontend - tests, build & couverture
     runs-on: ubuntu-latest
 
     defaults:
@@ -39,5 +39,65 @@ jobs:
       - name: Lancement des tests
         run: pnpm test
 
+      - name: Vérification du build
+        run: pnpm build
+
       - name: Vérification de la couverture (seuil 80%)
+        run: pnpm coverage
+
+  backend:
+    name: Backend - tests, build & couverture
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: pinball_user
+          POSTGRES_PASSWORD: pinball_test_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pinball_user -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      DATABASE_URL_TEST: postgresql://pinball_user:pinball_test_password@localhost:5432/postgres
+      DATABASE_URL: postgresql://pinball_user:pinball_test_password@localhost:5432/pinball_test_sandbox
+      BETTER_AUTH_SECRET: ci_backend_test_secret_do_not_use_in_production
+      BETTER_AUTH_URL: http://localhost:3000
+      FRONTEND_URL: http://localhost:5173
+      FRONTEND_ORIGINS: http://localhost:5173
+      SCORE_CLAIM_MODE: local
+
+    steps:
+      - name: Récupération du code source
+        uses: actions/checkout@v4
+
+      - name: Installation de pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Installation de Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Installation des dépendances
+        run: pnpm install --frozen-lockfile
+
+      - name: Vérification du build
+        run: pnpm build
+
+      - name: Vérification de la couverture backend (seuil 80%)
         run: pnpm coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,40 +2,6 @@
 .DS_Store
 Thumbs.db
 *.local
-
-# Node.js
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-
-# Docker
-.docker/
-
-# IDE / Editors
-.vscode/
-.idea/
-*.swp
-*.swo
-
-# MQTT
-mqtt/password_file.txt
-# Vite
-.vite/
-
-# Project specific
-dist/
-build/
-.env
-
-# .MD files
-docs/strategie-tests.md
-docs/suivi-auth-develop-sync.md 
-# OS
-.DS_Store
-Thumbs.db
-*.local
 *Zone.Identifier
 
 # Node.js
@@ -56,6 +22,7 @@ pnpm-debug.log*
 
 # MQTT
 mqtt/password_file.txt
+
 # Vite
 .vite/
 
@@ -63,3 +30,12 @@ mqtt/password_file.txt
 dist/
 build/
 .env
+.env.deploy
+
+# Local project notes
+docs/strategie-tests.md
+docs/suivi-auth-develop-sync.md
+
+# Personal documents
+HETIC_WEB3_Fiche_Focus_Epreuves_Ecrites.pdf
+PROJET fin d'année.pdf

--- a/README.md
+++ b/README.md
@@ -96,21 +96,37 @@ Variables à renseigner dans `.env` :
 - `BETTER_AUTH_SECRET`
 - `BETTER_AUTH_URL`
 - `FRONTEND_URL`
+- `FRONTEND_ORIGINS`
 - `GITHUB_CLIENT_ID`
 - `GITHUB_CLIENT_SECRET`
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
+- `SCORE_CLAIM_MODE`
+- `GLOBAL_API_URL`
+- `BORNE_TOKEN`
+
+Le flux QR code avec VPS est détaillé dans [docs/score-claim-vps.md](docs/score-claim-vps.md).
 
 ### Production
 
 En production, les migrations sont exécutées par le service `migrate` avant le démarrage du backend.
 Il n'y a pas d'interface d'administration de la base exposée.
 
-Commande de déploiement :
+Commande de déploiement VPS :
 
 ```bash
-docker compose -f compose.prod.yml up -d --build
+docker compose -p flipper-project -f deploy/docker-compose.vps.yml up -d --build
 ```
+
+Commande Pour voir si un score à été bien rattaché à un utilisateur :
+
+```bash
+sudo docker exec pinball-postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT scr.claim_code, scr.status, scr.user_id, u.email, scr.approved_at FROM score_claim_requests scr LEFT JOIN users u ON u.id = scr.user_id ORDER BY scr.created_at DESC LIMIT 10;"'
+```
+
+Le fichier `deploy/docker-compose.yml` reste réservé au déploiement du flipper
+physique via `fliphetic.toml`. Il build le frontend complet avec
+`VITE_APP_TARGET=flipper` par défaut.
 
 ---
 

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -16,3 +16,4 @@ BETTER_AUTH_SECRET=change_me_for_local_backend_tests_only
 BETTER_AUTH_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:5173
 FRONTEND_ORIGINS=http://localhost:5173
+SCORE_CLAIM_MODE=local

--- a/backend/src/app-session.ts
+++ b/backend/src/app-session.ts
@@ -1,0 +1,21 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+// Contrat minimal utilisé par l'application après authentification.
+// Better Auth renvoie plus d'informations que nécessaire ; on conserve ici
+// uniquement ce que les routes utilisent afin de ne pas coupler tout le backend
+// au type complet de la librairie.
+export type AppSession = {
+  session: unknown;
+  user: {
+    email?: string | null;
+    id: string;
+    username?: string | null;
+  };
+};
+
+// Abstraction volontaire pour les tests d'intégration.
+// Les routes peuvent demander "qui est connecté ?" sans connaître Better Auth,
+// ce qui permet d'injecter facilement une session mockée dans les tests.
+export type GetSession = (
+  headers: IncomingHttpHeaders,
+) => Promise<AppSession | null>;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,366 +1,76 @@
 import cors from "cors";
 import express, {
   type Express,
-  type NextFunction,
-  type Request,
   type RequestHandler,
-  type Response,
 } from "express";
 import { fromNodeHeaders, toNodeHandler } from "better-auth/node";
-import type { IncomingHttpHeaders } from "node:http";
-import { randomUUID } from "node:crypto";
-import { and, desc, eq, gt, isNull, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 
+import type { AppSession, GetSession } from "./app-session.js";
 import { getAuth, type AuthInstance } from "./auth.js";
 import { getDb, type DatabaseClient } from "./db/client.js";
-import {
-  games,
-  scoreClaimRequests,
-  type ScoreClaimStatus,
-  users,
-} from "./db/schema.js";
 import { env as defaultEnv } from "./env.js";
+import { createHttpError, requestErrorHandler } from "./http/errors.js";
+import { resetRateLimitStoreForTests } from "./http/rate-limit.js";
+import { registerScoreClaimRoutes } from "./routes/score-claim-routes.js";
 import {
-  LEADERBOARD_LIMIT,
-  SCORE_CLAIM_TTL_MS,
-  createScoreClaimCode,
-  evaluateScorePersistence,
-  getScoreClaimVerificationUrl,
-} from "./services/score-claim-service.js";
+  getRemoteScoreClaimStatus,
+  startRemoteScoreClaim,
+  type RemoteScoreClaimStatusChecker,
+  type RemoteScoreClaimStarter,
+} from "./services/remote-score-claim-client.js";
 
-const claimCodePattern = /^[A-Za-z0-9_-]{32}$/;
-const integerPattern = /^-?\d+$/;
-const postgresIntegerMax = 2_147_483_647;
-
-const scoreClaimStatus = {
-  pending: "pending",
-  approved: "approved",
-  expired: "expired",
-} as const satisfies Record<ScoreClaimStatus, ScoreClaimStatus>;
-
-type HttpError = Error & {
-  status?: number;
-  code?: string;
-};
-
-type RateLimitBucket = {
-  count: number;
-  resetAt: number;
-};
-
-type RateLimitRule = {
-  keyPrefix: string;
-  maxRequests: number;
-  windowMs: number;
-  errorCode: string;
-  message: string;
-  resolveKey: (request: Request) => string;
-};
-
-type AppSession = {
-  session: unknown;
-  user: {
-    email?: string | null;
-    id: string;
-    username?: string | null;
-  };
-};
-
+// `app.ts` assemble l'application Express.
+// Les règles métier lourdes restent dans des modules dédiés afin d'éviter
+// qu'Express, Better Auth, la base de données et le score-claim soient tous
+// mélangés dans un seul fichier.
 type BackendAppDependencies = {
   auth: AuthInstance;
   authRouteHandler: RequestHandler;
   db: DatabaseClient;
   env: typeof defaultEnv;
-  getSession: (headers: IncomingHttpHeaders) => Promise<AppSession | null>;
+  getSession: GetSession;
+  remoteScoreClaimStatusChecker: RemoteScoreClaimStatusChecker;
+  remoteScoreClaimStarter: RemoteScoreClaimStarter;
 };
 
-const rateLimitStore = new Map<string, RateLimitBucket>();
-
-export function resetRateLimitStoreForTests() {
-  rateLimitStore.clear();
-}
-
-function createHttpError(
-  status: number,
-  code: string,
-  message: string,
-): HttpError {
-  const error = new Error(message) as HttpError;
-  error.status = status;
-  error.code = code;
-  return error;
-}
-
-function isHttpError(error: unknown): error is HttpError {
-  return error instanceof Error;
-}
-
-function isInvalidJsonError(
-  error: unknown,
-): error is SyntaxError & { status: number } {
-  return (
-    error instanceof SyntaxError &&
-    typeof (error as { status?: unknown }).status === "number"
-  );
-}
-
-function getClientIp(request: Request): string {
-  return request.ip || request.socket.remoteAddress || "unknown";
-}
-
-function cleanupRateLimitStore(now: number) {
-  for (const [key, bucket] of rateLimitStore.entries()) {
-    if (bucket.resetAt <= now) {
-      rateLimitStore.delete(key);
-    }
-  }
-}
-
-function createRateLimitMiddleware(rule: RateLimitRule): RequestHandler {
-  return (request, _response, next) => {
-    const now = Date.now();
-    const bucketKey = `${rule.keyPrefix}:${rule.resolveKey(request)}`;
-    const currentBucket = rateLimitStore.get(bucketKey);
-
-    // Le rate limit reste en mémoire pour l'instant.
-    // Ce n'est pas encore distribué, mais cela suffit pour le flux local actuel.
-    if (rateLimitStore.size > 2_000) {
-      cleanupRateLimitStore(now);
-    }
-
-    if (!currentBucket || currentBucket.resetAt <= now) {
-      rateLimitStore.set(bucketKey, {
-        count: 1,
-        resetAt: now + rule.windowMs,
-      });
-      next();
-      return;
-    }
-
-    if (currentBucket.count >= rule.maxRequests) {
-      next(createHttpError(429, rule.errorCode, rule.message));
-      return;
-    }
-
-    currentBucket.count += 1;
-    next();
-  };
-}
-
-function isValidClaimCode(claimCode: string): boolean {
-  return claimCodePattern.test(claimCode);
-}
-
-function readSingleRouteParam(value: string | string[] | undefined): string {
-  if (Array.isArray(value)) {
-    return value[0] ?? "";
-  }
-
-  return value ?? "";
-}
-
-function assertValidClaimCode(claimCode: string) {
-  if (!isValidClaimCode(claimCode)) {
-    throw createHttpError(
-      400,
-      "invalid_claim_code",
-      "The claim code format is invalid.",
-    );
-  }
-}
-
-function isExpired(expiresAt: Date) {
-  return expiresAt.getTime() <= Date.now();
-}
-
-function parseRequiredInteger(
-  fieldName: string,
-  value: unknown,
-  options: { max?: number; min?: number } = {},
-) {
-  const normalizedValue = (() => {
-    if (typeof value === "number") {
-      return value;
-    }
-
-    if (typeof value === "string") {
-      const trimmedValue = value.trim();
-
-      if (integerPattern.test(trimmedValue)) {
-        return Number(trimmedValue);
-      }
-    }
-
-    return Number.NaN;
-  })();
-
-  if (!Number.isSafeInteger(normalizedValue)) {
-    throw createHttpError(400, `${fieldName}_invalid`, `${fieldName} must be an integer.`);
-  }
-
-  if (typeof options.min === "number" && normalizedValue < options.min) {
-    throw createHttpError(
-      400,
-      `${fieldName}_out_of_range`,
-      `${fieldName} must be greater than or equal to ${options.min}.`,
-    );
-  }
-
-  if (typeof options.max === "number" && normalizedValue > options.max) {
-    throw createHttpError(
-      400,
-      `${fieldName}_out_of_range`,
-      `${fieldName} must be less than or equal to ${options.max}.`,
-    );
-  }
-
-  return normalizedValue;
-}
-
-function parseBooleanFlag(value: unknown) {
-  if (typeof value === "boolean") {
-    return value;
-  }
-
-  if (value === "true") {
-    return true;
-  }
-
-  if (value === "false") {
-    return false;
-  }
-
-  if (typeof value === "undefined") {
-    return false;
-  }
-
-  throw createHttpError(400, "invalid_boolean_flag", "Boolean flag is invalid.");
-}
-
-function parseAppMode(value: unknown): "web" | "arcade" {
-  return value === "arcade" ? "arcade" : "web";
-}
+export { resetRateLimitStoreForTests };
 
 export function createApp(
   dependencies: Partial<BackendAppDependencies> = {},
 ): Express {
+  // Toutes les dépendances importantes sont injectables.
+  // Cela permet aux tests de remplacer la base, l'authentification ou l'appel
+  // VPS sans lancer de serveur réel ni toucher aux services externes.
   const auth = dependencies.auth ?? getAuth();
   const authRouteHandler = dependencies.authRouteHandler ?? toNodeHandler(auth);
   const db = dependencies.db ?? getDb();
   const env = dependencies.env ?? defaultEnv;
+  const remoteScoreClaimStarter =
+    dependencies.remoteScoreClaimStarter ?? startRemoteScoreClaim;
+  const remoteScoreClaimStatusChecker =
+    dependencies.remoteScoreClaimStatusChecker ?? getRemoteScoreClaimStatus;
   const getSession =
     dependencies.getSession ??
     // L'application n'a besoin que d'une forme minimale de session.
     // On évite donc d'imposer le type complet Better Auth aux helpers de test.
-    (async (headers: IncomingHttpHeaders) =>
+    (async (headers) =>
       (await auth.api.getSession({
         headers: fromNodeHeaders(headers),
       })) as AppSession | null);
 
   const app = express();
 
-  // Cette fonction est la future porte d'entrée des tests d'intégration.
-  // Les tests pourront importer l'app sans déclencher `listen()`.
+  // `createApp` reste le point d'entrée des tests : importer l'app ne doit pas
+  // lancer de serveur réseau ni ouvrir de port automatiquement.
   app.set("trust proxy", env.trustProxy);
-
-  async function wouldScoreEnterLeaderboard(finalScore: number) {
-    const topGames = await db
-      .select({
-        finalScore: games.finalScore,
-      })
-      .from(games)
-      .orderBy(desc(games.finalScore), desc(games.playedAt))
-      .limit(LEADERBOARD_LIMIT);
-
-    if (topGames.length < LEADERBOARD_LIMIT) {
-      return true;
-    }
-
-    const cutoffScore = topGames.at(-1)?.finalScore;
-
-    if (typeof cutoffScore !== "number") {
-      return true;
-    }
-
-    return finalScore >= cutoffScore;
-  }
-
-  async function expirePendingScoreClaimIfNeeded(
-    claimCode: string,
-    status: ScoreClaimStatus,
-    expiresAt: Date,
-  ): Promise<ScoreClaimStatus> {
-    if (status !== scoreClaimStatus.pending || !isExpired(expiresAt)) {
-      return status;
-    }
-
-    // L'expiration doit être reflétée en base, sinon deux lectures
-    // successives pourraient raconter deux histoires différentes.
-    await db
-      .update(scoreClaimRequests)
-      .set({
-        status: scoreClaimStatus.expired,
-      })
-      .where(
-        and(
-          eq(scoreClaimRequests.claimCode, claimCode),
-          eq(scoreClaimRequests.status, scoreClaimStatus.pending),
-        ),
-      );
-
-    return scoreClaimStatus.expired;
-  }
-
-  const limitScoreClaimStart = createRateLimitMiddleware({
-    keyPrefix: "score-claim-start",
-    maxRequests: 20,
-    windowMs: 10 * 60 * 1000,
-    errorCode: "too_many_score_claim_starts",
-    message: "Too many score claim start requests.",
-    resolveKey: (request) => getClientIp(request),
-  });
-
-  const limitScoreClaimStatusByIp = createRateLimitMiddleware({
-    keyPrefix: "score-claim-status-ip",
-    maxRequests: 120,
-    windowMs: 60 * 1000,
-    errorCode: "too_many_score_claim_status_requests",
-    message: "Too many score claim status requests.",
-    resolveKey: (request) => getClientIp(request),
-  });
-
-  const limitScoreClaimStatusByCode = createRateLimitMiddleware({
-    keyPrefix: "score-claim-status-code",
-    maxRequests: 30,
-    windowMs: 60 * 1000,
-    errorCode: "too_many_score_claim_status_requests",
-    message: "Too many score claim status requests for this claim code.",
-    resolveKey: (request) =>
-      readSingleRouteParam(request.params.claimCode) || "missing-claim-code",
-  });
-
-  const limitScoreClaimApproveByIp = createRateLimitMiddleware({
-    keyPrefix: "score-claim-approve-ip",
-    maxRequests: 20,
-    windowMs: 5 * 60 * 1000,
-    errorCode: "too_many_score_claim_approve_requests",
-    message: "Too many score claim approve requests.",
-    resolveKey: (request) => getClientIp(request),
-  });
-
-  const limitScoreClaimApproveByCode = createRateLimitMiddleware({
-    keyPrefix: "score-claim-approve-code",
-    maxRequests: 10,
-    windowMs: 5 * 60 * 1000,
-    errorCode: "too_many_score_claim_approve_requests",
-    message: "Too many score claim approve requests for this claim code.",
-    resolveKey: (request) =>
-      String(request.body?.claimCode ?? "missing-claim-code"),
-  });
 
   app.use(
     cors({
       origin(origin, callback) {
+        // Les requêtes sans `origin` correspondent souvent à curl, healthcheck
+        // ou appels server-to-server. Les navigateurs, eux, doivent venir d'une
+        // origine explicitement autorisée.
         if (!origin || env.frontendOrigins.includes(origin)) {
           callback(null, true);
           return;
@@ -386,6 +96,9 @@ export function createApp(
 
   app.get("/health", async (_request, response) => {
     try {
+      // Healthcheck utilisé par Docker ou par un futur reverse proxy.
+      // On teste réellement PostgreSQL pour détecter une app démarrée mais
+      // incapable de lire/écrire ses données.
       await db.execute(sql`select 1`);
 
       response.json({
@@ -403,6 +116,8 @@ export function createApp(
 
   app.get("/api/me", async (request, response) => {
     try {
+      // Route légère utilisée par le frontend pour savoir si une session existe.
+      // Elle ne déclenche pas de logique métier et reste séparée de Better Auth.
       const session = await getSession(request.headers);
 
       if (!session) {
@@ -423,364 +138,27 @@ export function createApp(
     }
   });
 
-  app.post(
-    "/api/score-claims/start",
-    limitScoreClaimStart,
-    async (request, response) => {
-      const finalScore = parseRequiredInteger("finalScore", request.body?.finalScore, {
-        max: postgresIntegerMax,
-        min: 0,
-      });
-      const playedDurationSeconds = parseRequiredInteger(
-        "playedDurationSeconds",
-        request.body?.playedDurationSeconds,
-        { max: postgresIntegerMax, min: 0 },
-      );
-      const requestClaim = parseBooleanFlag(request.body?.requestClaim);
-      const mode = parseAppMode(request.body?.mode);
-      const session = await getSession(request.headers);
+  registerScoreClaimRoutes({
+    // Les routes score-claim sont regroupées dans leur propre module parce
+    // qu'elles contiennent la majorité de la logique métier QR/VPS.
+    app,
+    db,
+    env,
+    getSession,
+    remoteScoreClaimStatusChecker,
+    remoteScoreClaimStarter,
+  });
 
-      const shouldCheckLeaderboard = !session && !requestClaim;
-      const leaderboardEligible = shouldCheckLeaderboard
-        ? await wouldScoreEnterLeaderboard(finalScore)
-        : false;
-
-      const evaluation = evaluateScorePersistence({
-        finalScore,
-        isAuthenticated: Boolean(session),
-        mode,
-        playedDurationSeconds,
-        requestClaim,
-        wouldEnterLeaderboard: leaderboardEligible,
-      });
-
-      if (evaluation.decision === "discard") {
-        response.json({
-          decision: evaluation.decision,
-          reason: evaluation.reason,
-          game: null,
-          claim: null,
-        });
-        return;
-      }
-
-      const playedAt = new Date();
-      const [persistedGame, persistedClaim] = await db.transaction(async (tx) => {
-        const [createdGame] = await tx
-          .insert(games)
-          .values({
-            userId: session?.user.id ?? null,
-            playedDurationSeconds,
-            finalScore,
-            playedAt,
-          })
-          .returning({
-            id: games.id,
-            finalScore: games.finalScore,
-            playedAt: games.playedAt,
-            playedDurationSeconds: games.playedDurationSeconds,
-          });
-
-        if (evaluation.decision !== "save_and_claimable") {
-          return [createdGame, null] as const;
-        }
-
-        const claimCode = createScoreClaimCode();
-        const expiresAt = new Date(Date.now() + SCORE_CLAIM_TTL_MS);
-
-        const [createdClaim] = await tx
-          .insert(scoreClaimRequests)
-          .values({
-            id: randomUUID(),
-            gameId: createdGame.id,
-            claimCode,
-            status: scoreClaimStatus.pending,
-            expiresAt,
-          })
-          .returning({
-            claimCode: scoreClaimRequests.claimCode,
-            expiresAt: scoreClaimRequests.expiresAt,
-          });
-
-        return [createdGame, createdClaim] as const;
-      });
-
-      response.status(201).json({
-        decision: evaluation.decision,
-        reason: evaluation.reason,
-        game: {
-          id: persistedGame.id,
-          finalScore: persistedGame.finalScore,
-          playedAt: persistedGame.playedAt.toISOString(),
-          playedDurationSeconds: persistedGame.playedDurationSeconds,
-        },
-        claim: persistedClaim
-          ? {
-              claimCode: persistedClaim.claimCode,
-              expiresAt: persistedClaim.expiresAt.toISOString(),
-              status: scoreClaimStatus.pending,
-              verificationUrl: getScoreClaimVerificationUrl(
-                env.frontendUrl,
-                persistedClaim.claimCode,
-              ),
-            }
-          : null,
-      });
-    },
-  );
-
-  app.get(
-    "/api/score-claims/status/:claimCode",
-    limitScoreClaimStatusByIp,
-    limitScoreClaimStatusByCode,
-    async (request, response) => {
-      const claimCode = readSingleRouteParam(request.params.claimCode);
-
-      assertValidClaimCode(claimCode);
-
-      const [scoreClaim] = await db
-        .select({
-          status: scoreClaimRequests.status,
-          expiresAt: scoreClaimRequests.expiresAt,
-          approvedAt: scoreClaimRequests.approvedAt,
-          userId: scoreClaimRequests.userId,
-          username: users.username,
-          gameId: games.id,
-          finalScore: games.finalScore,
-          playedAt: games.playedAt,
-          playedDurationSeconds: games.playedDurationSeconds,
-        })
-        .from(scoreClaimRequests)
-        .innerJoin(games, eq(scoreClaimRequests.gameId, games.id))
-        .leftJoin(users, eq(scoreClaimRequests.userId, users.id))
-        .where(eq(scoreClaimRequests.claimCode, claimCode))
-        .limit(1);
-
-      if (!scoreClaim) {
-        response.status(404).json({ status: "not_found" });
-        return;
-      }
-
-      const effectiveStatus = await expirePendingScoreClaimIfNeeded(
-        claimCode,
-        scoreClaim.status,
-        scoreClaim.expiresAt,
-      );
-
-      if (effectiveStatus === scoreClaimStatus.expired) {
-        response.status(410).json({ status: "expired" });
-        return;
-      }
-
-      response.json({
-        status: effectiveStatus,
-        user: scoreClaim.userId
-          ? {
-              username: scoreClaim.username,
-            }
-          : null,
-        game: {
-          id: scoreClaim.gameId,
-          finalScore: scoreClaim.finalScore,
-          playedAt: scoreClaim.playedAt.toISOString(),
-          playedDurationSeconds: scoreClaim.playedDurationSeconds,
-        },
-        approvedAt: scoreClaim.approvedAt?.toISOString() ?? null,
-        expiresAt: scoreClaim.expiresAt.toISOString(),
-      });
-    },
-  );
-
-  app.post(
-    "/api/score-claims/approve",
-    limitScoreClaimApproveByIp,
-    limitScoreClaimApproveByCode,
-    async (request, response) => {
-      const claimCode = String(request.body?.claimCode ?? "");
-
-      if (!claimCode) {
-        response.status(400).json({ error: "claim_code_required" });
-        return;
-      }
-
-      assertValidClaimCode(claimCode);
-
-      const session = await getSession(request.headers);
-
-      if (!session) {
-        response.status(401).json({ error: "authentication_required" });
-        return;
-      }
-
-      const approvalResult = await db.transaction(async (tx) => {
-        // On approuve d'abord le claim, puis on rattache la partie.
-        // La transaction garantit qu'aucune requête concurrente ne laisse
-        // un état intermédiaire incohérent.
-        const [approvedClaim] = await tx
-          .update(scoreClaimRequests)
-          .set({
-            status: scoreClaimStatus.approved,
-            userId: session.user.id,
-            approvedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(scoreClaimRequests.claimCode, claimCode),
-              eq(scoreClaimRequests.status, scoreClaimStatus.pending),
-              gt(scoreClaimRequests.expiresAt, new Date()),
-            ),
-          )
-          .returning({
-            gameId: scoreClaimRequests.gameId,
-          });
-
-        if (approvedClaim) {
-          const [claimedGame] = await tx
-            .update(games)
-            .set({
-              userId: session.user.id,
-            })
-            .where(
-              and(
-                eq(games.id, approvedClaim.gameId),
-                isNull(games.userId),
-              ),
-            )
-            .returning({
-              id: games.id,
-              finalScore: games.finalScore,
-            });
-
-          if (!claimedGame) {
-            throw createHttpError(
-              409,
-              "score_claim_game_already_owned",
-              "The score claim game is already attached to a user.",
-            );
-          }
-
-          return {
-            kind: "approved" as const,
-            game: claimedGame,
-          };
-        }
-
-        const [existingClaim] = await tx
-          .select({
-            status: scoreClaimRequests.status,
-            expiresAt: scoreClaimRequests.expiresAt,
-            gameId: scoreClaimRequests.gameId,
-            finalScore: games.finalScore,
-          })
-          .from(scoreClaimRequests)
-          .innerJoin(games, eq(scoreClaimRequests.gameId, games.id))
-          .where(eq(scoreClaimRequests.claimCode, claimCode))
-          .limit(1);
-
-        if (!existingClaim) {
-          return { kind: "missing" as const };
-        }
-
-        if (
-          existingClaim.status === scoreClaimStatus.pending &&
-          isExpired(existingClaim.expiresAt)
-        ) {
-          await tx
-            .update(scoreClaimRequests)
-            .set({
-              status: scoreClaimStatus.expired,
-            })
-            .where(
-              and(
-                eq(scoreClaimRequests.claimCode, claimCode),
-                eq(scoreClaimRequests.status, scoreClaimStatus.pending),
-              ),
-            );
-
-          return { kind: "expired" as const };
-        }
-
-        if (existingClaim.status === scoreClaimStatus.approved) {
-          return {
-            kind: "already-approved" as const,
-            game: {
-              id: existingClaim.gameId,
-              finalScore: existingClaim.finalScore,
-            },
-          };
-        }
-
-        return { kind: "conflict" as const };
-      });
-
-      if (
-        approvalResult.kind === "approved" ||
-        approvalResult.kind === "already-approved"
-      ) {
-        response.json({
-          status: scoreClaimStatus.approved,
-          game: approvalResult.game,
-        });
-        return;
-      }
-
-      if (approvalResult.kind === "missing") {
-        response.status(404).json({ error: "score_claim_not_found" });
-        return;
-      }
-
-      if (approvalResult.kind === "expired") {
-        response.status(410).json({ error: "score_claim_expired" });
-        return;
-      }
-
-      throw createHttpError(
-        409,
-        "score_claim_approval_conflict",
-        "The score claim request could not be approved safely.",
-      );
-    },
-  );
-
-  app.use(
-    (
-      error: unknown,
-      _request: Request,
-      response: Response,
-      next: NextFunction,
-    ) => {
-      if (response.headersSent) {
-        next(error);
-        return;
-      }
-
-      if (isInvalidJsonError(error)) {
-        response.status(400).json({ error: "invalid_json_body" });
-        return;
-      }
-
-      if (isHttpError(error)) {
-        const status = error.status ?? 500;
-
-        if (status >= 500) {
-          console.error("Unhandled request error:", error);
-        }
-
-        response.status(status).json({
-          error: error.code ?? "internal_server_error",
-        });
-        return;
-      }
-
-      console.error("Unhandled request error:", error);
-      response.status(500).json({ error: "internal_server_error" });
-    },
-  );
+  // Le gestionnaire d'erreurs doit rester le dernier middleware Express.
+  // Toutes les routes au-dessus peuvent lever `createHttpError(...)`.
+  app.use(requestErrorHandler);
 
   return app;
 }
 
 export function startServer(app: Express, port: number) {
+  // Séparé de `createApp` pour que les tests puissent importer l'application
+  // sans ouvrir de port réseau.
   return app.listen(port, () => {
     console.log(`Backend listening on port ${port}`);
   });

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -23,6 +23,9 @@ function createSocialProviders(authEnv: AuthEnv) {
     socialProviders.github = {
       clientId: authEnv.githubClientId,
       clientSecret: authEnv.githubClientSecret,
+      // Better Auth demande déjà `read:user` et `user:email`, puis lit
+      // `/user/emails`. On ne crée pas d'email de secours : si GitHub ne
+      // fournit pas d'email, cela révèle un problème de permission OAuth.
     };
   }
 

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,8 +1,7 @@
 import "dotenv/config";
 
 type TrustProxySetting = boolean | number;
-
-const integerPattern = /^\d+$/;
+type ScoreClaimMode = "local" | "remote";
 
 function requireEnv(name: string): string {
   const value = process.env[name]?.trim();
@@ -24,8 +23,18 @@ function optionalEnv(name: string): string | undefined {
   return value;
 }
 
+function isUnsignedIntegerText(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  // Validation volontairement explicite plutôt qu'une regex : c'est plus
+  // simple à justifier en soutenance et cela évite les cas ambigus.
+  return [...value].every((character) => character >= "0" && character <= "9");
+}
+
 function parsePort(value: string): number {
-  if (!integerPattern.test(value.trim())) {
+  if (!isUnsignedIntegerText(value.trim())) {
     throw new Error("PORT must be an integer between 1 and 65535.");
   }
 
@@ -53,7 +62,7 @@ function parseTrustProxy(value: string | undefined): TrustProxySetting {
     return false;
   }
 
-  if (!integerPattern.test(normalizedValue)) {
+  if (!isUnsignedIntegerText(normalizedValue)) {
     throw new Error("TRUST_PROXY must be `true`, `false` or a non-negative integer.");
   }
 
@@ -92,6 +101,16 @@ function readUrlEnv(name: string, defaultValue?: string): string {
   throw new Error(`${name} is required.`);
 }
 
+function readOptionalUrlEnv(name: string): string | undefined {
+  const value = optionalEnv(name);
+
+  if (!value) {
+    return undefined;
+  }
+
+  return parseUrl(name, value);
+}
+
 function listEnv(name: string): string[] {
   return (
     process.env[name]
@@ -99,6 +118,20 @@ function listEnv(name: string): string[] {
       .map((value) => value.trim())
       .filter(Boolean) ?? []
   );
+}
+
+function parseScoreClaimMode(value: string | undefined): ScoreClaimMode {
+  if (!value) {
+    return "local";
+  }
+
+  const normalizedValue = value.toLowerCase();
+
+  if (normalizedValue === "local" || normalizedValue === "remote") {
+    return normalizedValue;
+  }
+
+  throw new Error("SCORE_CLAIM_MODE must be `local` or `remote`.");
 }
 
 const nodeEnv = optionalEnv("NODE_ENV") ?? "development";
@@ -122,6 +155,20 @@ const frontendOrigins = Array.from(
     ),
   ]),
 );
+const scoreClaimMode = parseScoreClaimMode(optionalEnv("SCORE_CLAIM_MODE"));
+const globalApiUrl = readOptionalUrlEnv("GLOBAL_API_URL");
+const borneToken = optionalEnv("BORNE_TOKEN");
+
+// En mode remote, le backend local de la borne ne doit jamais accepter de
+// démarrer avec une configuration incomplète : sinon le QR code serait absent
+// ou pointerait vers une cible inutilisable après une vraie partie.
+if (scoreClaimMode === "remote" && !globalApiUrl) {
+  throw new Error("GLOBAL_API_URL is required when SCORE_CLAIM_MODE=remote.");
+}
+
+if (scoreClaimMode === "remote" && !borneToken) {
+  throw new Error("BORNE_TOKEN is required when SCORE_CLAIM_MODE=remote.");
+}
 
 export const env = {
   nodeEnv,
@@ -134,6 +181,9 @@ export const env = {
   betterAuthOrigin: new URL(betterAuthUrl).origin,
   frontendUrl,
   frontendOrigins,
+  scoreClaimMode,
+  globalApiUrl,
+  borneToken,
   githubClientId: optionalEnv("GITHUB_CLIENT_ID"),
   githubClientSecret: optionalEnv("GITHUB_CLIENT_SECRET"),
   googleClientId: optionalEnv("GOOGLE_CLIENT_ID"),

--- a/backend/src/http/bearer-token.ts
+++ b/backend/src/http/bearer-token.ts
@@ -1,0 +1,30 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Lit uniquement le format standard `Authorization: Bearer <token>`.
+// On ne supporte pas d'autres formats pour éviter une authentification ambiguë.
+export function readBearerToken(authorizationHeader: string | undefined): string | null {
+  const bearerPrefix = "Bearer ";
+
+  if (!authorizationHeader?.startsWith(bearerPrefix)) {
+    return null;
+  }
+
+  const token = authorizationHeader.slice(bearerPrefix.length).trim();
+  return token.length > 0 ? token : null;
+}
+
+// Comparaison en temps constant pour éviter de révéler progressivement le token
+// via des différences de temps de réponse. C'est important pour BORNE_TOKEN,
+// qui autorise une borne physique à créer des claims sur le VPS.
+export function tokensMatch(providedToken: string, expectedToken: string): boolean {
+  const providedBuffer = Buffer.from(providedToken);
+  const expectedBuffer = Buffer.from(expectedToken);
+
+  if (providedBuffer.length !== expectedBuffer.length) {
+    // `timingSafeEqual` exige deux buffers de même taille.
+    // On refuse immédiatement les tailles différentes.
+    return false;
+  }
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}

--- a/backend/src/http/errors.ts
+++ b/backend/src/http/errors.ts
@@ -1,0 +1,77 @@
+import type { NextFunction, Request, Response } from "express";
+
+// Erreur HTTP normalisée pour tout le backend.
+// L'objectif est de renvoyer un code machine stable (`code`) au frontend,
+// sans exposer les messages internes ou une stack trace en production.
+export type HttpError = Error & {
+  status?: number;
+  code?: string;
+};
+
+// Fabrique d'erreur utilisée dans les routes et middlewares.
+// Elle évite de répéter partout `response.status(...).json(...)` et laisse
+// le middleware final formater la réponse de manière uniforme.
+export function createHttpError(
+  status: number,
+  code: string,
+  message: string,
+): HttpError {
+  const error = new Error(message) as HttpError;
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+function isHttpError(error: unknown): error is HttpError {
+  // Toute erreur JavaScript peut arriver jusqu'ici. Si elle porte `status`
+  // et `code`, on les utilise ; sinon elle sera traitée comme une 500.
+  return error instanceof Error;
+}
+
+function isInvalidJsonError(
+  error: unknown,
+): error is SyntaxError & { status: number } {
+  return (
+    error instanceof SyntaxError &&
+    typeof (error as { status?: unknown }).status === "number"
+  );
+}
+
+export function requestErrorHandler(
+  error: unknown,
+  _request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  if (response.headersSent) {
+    // Express ne permet plus de modifier la réponse si des headers sont déjà
+    // partis. Dans ce cas on délègue au handler par défaut.
+    next(error);
+    return;
+  }
+
+  if (isInvalidJsonError(error)) {
+    // `express.json()` lève une SyntaxError sur un JSON invalide.
+    // On transforme ce cas fréquent en erreur client claire.
+    response.status(400).json({ error: "invalid_json_body" });
+    return;
+  }
+
+  if (isHttpError(error)) {
+    const status = error.status ?? 500;
+
+    if (status >= 500) {
+      // Les erreurs serveur sont loggées côté backend, mais le client reçoit
+      // seulement un code stable pour éviter les fuites d'informations.
+      console.error("Unhandled request error:", error);
+    }
+
+    response.status(status).json({
+      error: error.code ?? "internal_server_error",
+    });
+    return;
+  }
+
+  console.error("Unhandled request error:", error);
+  response.status(500).json({ error: "internal_server_error" });
+}

--- a/backend/src/http/rate-limit.ts
+++ b/backend/src/http/rate-limit.ts
@@ -1,0 +1,82 @@
+import type { Request, RequestHandler } from "express";
+
+import { createHttpError } from "./errors.js";
+
+// Le rate-limit est volontairement simple et en mémoire.
+// C'est suffisant pour un backend mono-instance de borne/VPS de projet, mais
+// il faudra le remplacer par Redis ou équivalent si plusieurs instances backend
+// tournent derrière un load balancer.
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+// Chaque route choisit sa clé et ses limites.
+// Cela permet par exemple de limiter par IP, puis par claimCode sur la même route.
+type RateLimitRule = {
+  keyPrefix: string;
+  maxRequests: number;
+  windowMs: number;
+  errorCode: string;
+  message: string;
+  resolveKey: (request: Request) => string;
+};
+
+const rateLimitStore = new Map<string, RateLimitBucket>();
+
+export function resetRateLimitStoreForTests() {
+  // Les tests doivent rester isolés : sans reset, une suite peut polluer la
+  // suivante en consommant les quotas de rate-limit.
+  rateLimitStore.clear();
+}
+
+export function getClientIp(request: Request): string {
+  // `request.ip` respecte `trust proxy`. Le fallback socket sert surtout aux
+  // tests et aux environnements sans proxy.
+  return request.ip || request.socket.remoteAddress || "unknown";
+}
+
+function cleanupRateLimitStore(now: number) {
+  // Nettoyage opportuniste : on évite un interval global permanent.
+  // Le store est purgé uniquement quand une requête arrive.
+  for (const [key, bucket] of rateLimitStore.entries()) {
+    if (bucket.resetAt <= now) {
+      rateLimitStore.delete(key);
+    }
+  }
+}
+
+export function createRateLimitMiddleware(rule: RateLimitRule): RequestHandler {
+  return (request, _response, next) => {
+    const now = Date.now();
+    const bucketKey = `${rule.keyPrefix}:${rule.resolveKey(request)}`;
+    const currentBucket = rateLimitStore.get(bucketKey);
+
+    // Le rate limit reste en mémoire pour l'instant.
+    // Ce n'est pas encore distribué, mais cela suffit pour le flux local actuel.
+    if (rateLimitStore.size > 2_000) {
+      cleanupRateLimitStore(now);
+    }
+
+    if (!currentBucket || currentBucket.resetAt <= now) {
+      // Nouveau créneau de temps : on initialise le compteur et sa date
+      // d'expiration.
+      rateLimitStore.set(bucketKey, {
+        count: 1,
+        resetAt: now + rule.windowMs,
+      });
+      next();
+      return;
+    }
+
+    if (currentBucket.count >= rule.maxRequests) {
+      // On passe par `next(error)` pour conserver le format d'erreur HTTP
+      // centralisé dans `requestErrorHandler`.
+      next(createHttpError(429, rule.errorCode, rule.message));
+      return;
+    }
+
+    currentBucket.count += 1;
+    next();
+  };
+}

--- a/backend/src/http/request-parsing.ts
+++ b/backend/src/http/request-parsing.ts
@@ -1,0 +1,106 @@
+import { createHttpError } from "./errors.js";
+
+// PostgreSQL `integer` est limité à 32 bits signé.
+// On borne les scores/durées avant insertion pour éviter une erreur SQL tardive.
+export const postgresIntegerMax = 2_147_483_647;
+
+function isDecimalIntegerText(value: string): boolean {
+  const trimmedValue = value.trim();
+  const firstDigitIndex = trimmedValue.startsWith("-") ? 1 : 0;
+
+  if (trimmedValue.length === firstDigitIndex) {
+    return false;
+  }
+
+  // Validation explicite plutôt qu'une regex : elle est plus lisible pour la
+  // soutenance et évite les surprises liées aux formats numériques ambigus.
+  for (let index = firstDigitIndex; index < trimmedValue.length; index += 1) {
+    const character = trimmedValue[index];
+
+    if (character < "0" || character > "9") {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function readSingleRouteParam(value: string | string[] | undefined): string {
+  // Express peut typer certains paramètres comme tableau.
+  // Nos routes attendent toujours un seul identifiant dans l'URL.
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+
+  return value ?? "";
+}
+
+export function parseRequiredInteger(
+  fieldName: string,
+  value: unknown,
+  options: { max?: number; min?: number } = {},
+) {
+  // Les clients peuvent envoyer les nombres comme number ou string.
+  // On accepte les deux, mais seulement si la valeur est un entier strict.
+  const normalizedValue = (() => {
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const trimmedValue = value.trim();
+
+      if (isDecimalIntegerText(trimmedValue)) {
+        return Number(trimmedValue);
+      }
+    }
+
+    return Number.NaN;
+  })();
+
+  if (!Number.isSafeInteger(normalizedValue)) {
+    // On renvoie un code d'erreur spécifique au champ pour que le frontend ou
+    // les tests puissent diagnostiquer précisément la donnée invalide.
+    throw createHttpError(400, `${fieldName}_invalid`, `${fieldName} must be an integer.`);
+  }
+
+  if (typeof options.min === "number" && normalizedValue < options.min) {
+    throw createHttpError(
+      400,
+      `${fieldName}_out_of_range`,
+      `${fieldName} must be greater than or equal to ${options.min}.`,
+    );
+  }
+
+  if (typeof options.max === "number" && normalizedValue > options.max) {
+    throw createHttpError(
+      400,
+      `${fieldName}_out_of_range`,
+      `${fieldName} must be less than or equal to ${options.max}.`,
+    );
+  }
+
+  return normalizedValue;
+}
+
+export function parseBooleanFlag(value: unknown) {
+  // Les formulaires/API peuvent transmettre un booléen réel ou une string.
+  // `undefined` vaut false pour les flags optionnels comme `requestClaim`.
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  if (typeof value === "undefined") {
+    return false;
+  }
+
+  throw createHttpError(400, "invalid_boolean_flag", "Boolean flag is invalid.");
+}

--- a/backend/src/routes/score-claim-routes.ts
+++ b/backend/src/routes/score-claim-routes.ts
@@ -1,0 +1,683 @@
+import type { Express } from "express";
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, gt, isNull } from "drizzle-orm";
+
+import type { AppSession, GetSession } from "../app-session.js";
+import type { DatabaseClient } from "../db/client.js";
+import {
+  games,
+  scoreClaimRequests,
+  type ScoreClaimStatus,
+  users,
+} from "../db/schema.js";
+import type { env as defaultEnv } from "../env.js";
+import { readBearerToken, tokensMatch } from "../http/bearer-token.js";
+import { createHttpError } from "../http/errors.js";
+import {
+  getClientIp,
+  createRateLimitMiddleware,
+} from "../http/rate-limit.js";
+import {
+  parseBooleanFlag,
+  parseRequiredInteger,
+  postgresIntegerMax,
+  readSingleRouteParam,
+} from "../http/request-parsing.js";
+import type {
+  RemoteScoreClaimStatusChecker,
+  RemoteScoreClaimStarter,
+} from "../services/remote-score-claim-client.js";
+import {
+  LEADERBOARD_LIMIT,
+  SCORE_CLAIM_TTL_MS,
+  type ScoreClaimStartPayload,
+  type ScoreClaimStartResponse,
+  createScoreClaimCode,
+  evaluateScorePersistence,
+  getScoreClaimVerificationUrl,
+} from "../services/score-claim-service.js";
+
+// Ce module regroupe tout le flux "score claim".
+// Il a été sorti de `app.ts` pour garder `app.ts` comme fichier d'assemblage
+// Express, tandis qu'ici on garde les règles métier liées au QR code, au VPS
+// et au rattachement d'un score à un utilisateur.
+type RegisterScoreClaimRoutesDependencies = {
+  app: Express;
+  db: DatabaseClient;
+  env: typeof defaultEnv;
+  getSession: GetSession;
+  remoteScoreClaimStatusChecker: RemoteScoreClaimStatusChecker;
+  remoteScoreClaimStarter: RemoteScoreClaimStarter;
+};
+
+const claimCodeLength = 32;
+
+// Copie locale des statuts autorisés par le schéma.
+// `satisfies` garantit que si le type Drizzle évolue, TypeScript nous force
+// à mettre ce mapping à jour.
+const scoreClaimStatus = {
+  pending: "pending",
+  approved: "approved",
+  expired: "expired",
+} as const satisfies Record<ScoreClaimStatus, ScoreClaimStatus>;
+
+function isClaimCodeCharacter(character: string): boolean {
+  const isUppercaseLetter = character >= "A" && character <= "Z";
+  const isLowercaseLetter = character >= "a" && character <= "z";
+  const isDigit = character >= "0" && character <= "9";
+
+  return (
+    isUppercaseLetter ||
+    isLowercaseLetter ||
+    isDigit ||
+    character === "_" ||
+    character === "-"
+  );
+}
+
+function isValidClaimCode(claimCode: string): boolean {
+  // Les claim codes sont générés côté serveur. En entrée utilisateur, on valide
+  // strictement la taille et l'alphabet autorisé avant toute requête SQL.
+  if (claimCode.length !== claimCodeLength) {
+    return false;
+  }
+
+  for (const character of claimCode) {
+    if (!isClaimCodeCharacter(character)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function assertValidClaimCode(claimCode: string) {
+  if (!isValidClaimCode(claimCode)) {
+    throw createHttpError(
+      400,
+      "invalid_claim_code",
+      "The claim code format is invalid.",
+    );
+  }
+}
+
+function isExpired(expiresAt: Date) {
+  return expiresAt.getTime() <= Date.now();
+}
+
+function parseAppMode(value: unknown): "web" | "arcade" {
+  // Par défaut on considère le mode web : seul `arcade` déclenche le flux QR
+  // destiné à une borne physique.
+  return value === "arcade" ? "arcade" : "web";
+}
+
+function parseScoreClaimStartPayload(body: unknown): ScoreClaimStartPayload {
+  // Toutes les routes de démarrage de claim partagent le même parsing.
+  // Cela évite qu'une borne remote et le backend local interprètent différemment
+  // le score, la durée ou le mode de jeu.
+  const requestBody =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>)
+      : {};
+
+  return {
+    finalScore: parseRequiredInteger("finalScore", requestBody.finalScore, {
+      max: postgresIntegerMax,
+      min: 0,
+    }),
+    mode: parseAppMode(requestBody.mode),
+    playedDurationSeconds: parseRequiredInteger(
+      "playedDurationSeconds",
+      requestBody.playedDurationSeconds,
+      { max: postgresIntegerMax, min: 0 },
+    ),
+    requestClaim: parseBooleanFlag(requestBody.requestClaim),
+  };
+}
+
+function getScoreClaimStartStatus(response: ScoreClaimStartResponse) {
+  // Un score ignoré n'a rien créé en base : 200.
+  // Un score sauvegardé ou claimable a créé une ressource : 201.
+  return response.decision === "discard" ? 200 : 201;
+}
+
+export function registerScoreClaimRoutes({
+  app,
+  db,
+  env,
+  getSession,
+  remoteScoreClaimStatusChecker,
+  remoteScoreClaimStarter,
+}: RegisterScoreClaimRoutesDependencies) {
+  async function wouldScoreEnterLeaderboard(finalScore: number) {
+    // Pour un joueur non connecté qui ne réclame pas explicitement son score,
+    // on sauvegarde seulement si le score peut entrer dans le leaderboard.
+    // Cela évite de remplir la base avec des parties insignifiantes.
+    const topGames = await db
+      .select({
+        finalScore: games.finalScore,
+      })
+      .from(games)
+      .orderBy(desc(games.finalScore), desc(games.playedAt))
+      .limit(LEADERBOARD_LIMIT);
+
+    if (topGames.length < LEADERBOARD_LIMIT) {
+      return true;
+    }
+
+    const cutoffScore = topGames.at(-1)?.finalScore;
+
+    if (typeof cutoffScore !== "number") {
+      return true;
+    }
+
+    return finalScore >= cutoffScore;
+  }
+
+  async function startLocalScoreClaim(
+    payload: ScoreClaimStartPayload,
+    session: AppSession | null,
+  ): Promise<ScoreClaimStartResponse> {
+    // "Local" signifie : écrire dans la base du backend courant.
+    // Sur le VPS c'est le comportement normal. Sur le flipper réel, on peut
+    // basculer en mode remote pour que la source de vérité devienne le VPS.
+    const shouldCheckLeaderboard = !session && !payload.requestClaim;
+    const leaderboardEligible = shouldCheckLeaderboard
+      ? await wouldScoreEnterLeaderboard(payload.finalScore)
+      : false;
+
+    const evaluation = evaluateScorePersistence({
+      finalScore: payload.finalScore,
+      isAuthenticated: Boolean(session),
+      mode: payload.mode,
+      playedDurationSeconds: payload.playedDurationSeconds,
+      requestClaim: payload.requestClaim,
+      wouldEnterLeaderboard: leaderboardEligible,
+    });
+
+    if (evaluation.decision === "discard") {
+      // Aucun score ni claim n'est créé si les règles métier indiquent que la
+      // partie n'est pas significative.
+      return {
+        claim: null,
+        decision: evaluation.decision,
+        game: null,
+        reason: evaluation.reason,
+      };
+    }
+
+    const playedAt = new Date();
+    const [persistedGame, persistedClaim] = await db.transaction(async (tx) => {
+      // La création du score et du claim doit être atomique :
+      // on ne veut jamais un QR code sans partie associée, ni l'inverse.
+      const [createdGame] = await tx
+        .insert(games)
+        .values({
+          userId: session?.user.id ?? null,
+          playedDurationSeconds: payload.playedDurationSeconds,
+          finalScore: payload.finalScore,
+          playedAt,
+        })
+        .returning({
+          id: games.id,
+          finalScore: games.finalScore,
+          playedAt: games.playedAt,
+          playedDurationSeconds: games.playedDurationSeconds,
+        });
+
+      if (evaluation.decision !== "save_and_claimable") {
+        // Cas joueur déjà authentifié ou score leaderboard sans claim mobile.
+        return [createdGame, null] as const;
+      }
+
+      const claimCode = createScoreClaimCode();
+      const expiresAt = new Date(Date.now() + SCORE_CLAIM_TTL_MS);
+
+      // Le claim est temporaire. Le téléphone scanne le QR, puis l'utilisateur
+      // doit s'authentifier avant expiration pour rattacher la partie.
+      const [createdClaim] = await tx
+        .insert(scoreClaimRequests)
+        .values({
+          id: randomUUID(),
+          gameId: createdGame.id,
+          claimCode,
+          status: scoreClaimStatus.pending,
+          expiresAt,
+        })
+        .returning({
+          claimCode: scoreClaimRequests.claimCode,
+          expiresAt: scoreClaimRequests.expiresAt,
+        });
+
+      return [createdGame, createdClaim] as const;
+    });
+
+    return {
+      decision: evaluation.decision,
+      reason: evaluation.reason,
+      game: {
+        id: persistedGame.id,
+        finalScore: persistedGame.finalScore,
+        playedAt: persistedGame.playedAt.toISOString(),
+        playedDurationSeconds: persistedGame.playedDurationSeconds,
+      },
+      claim: persistedClaim
+        ? {
+            claimCode: persistedClaim.claimCode,
+            expiresAt: persistedClaim.expiresAt.toISOString(),
+            status: scoreClaimStatus.pending,
+            verificationUrl: getScoreClaimVerificationUrl(
+              // Cette URL doit être publique sur le VPS. En mode remote, elle
+              // vient de la réponse VPS et non du localhost de la borne.
+              env.frontendUrl,
+              persistedClaim.claimCode,
+            ),
+          }
+        : null,
+    };
+  }
+
+  async function expirePendingScoreClaimIfNeeded(
+    claimCode: string,
+    status: ScoreClaimStatus,
+    expiresAt: Date,
+  ): Promise<ScoreClaimStatus> {
+    if (status !== scoreClaimStatus.pending || !isExpired(expiresAt)) {
+      return status;
+    }
+
+    // L'expiration doit être reflétée en base, sinon deux lectures
+    // successives pourraient raconter deux histoires différentes.
+    await db
+      .update(scoreClaimRequests)
+      .set({
+        status: scoreClaimStatus.expired,
+      })
+      .where(
+        and(
+          eq(scoreClaimRequests.claimCode, claimCode),
+          eq(scoreClaimRequests.status, scoreClaimStatus.pending),
+        ),
+      );
+
+    return scoreClaimStatus.expired;
+  }
+
+  const limitScoreClaimStart = createRateLimitMiddleware({
+    // Protège la route appelée par le front/backglass local en fin de partie.
+    keyPrefix: "score-claim-start",
+    maxRequests: 20,
+    windowMs: 10 * 60 * 1000,
+    errorCode: "too_many_score_claim_starts",
+    message: "Too many score claim start requests.",
+    resolveKey: (request) => getClientIp(request),
+  });
+
+  const limitBorneScoreClaimStart = createRateLimitMiddleware({
+    // Route server-to-server exposée par le VPS. Elle a un quota plus élevé
+    // parce qu'elle peut être appelée par une borne réelle, mais reste limitée.
+    keyPrefix: "borne-score-claim-start",
+    maxRequests: 60,
+    windowMs: 10 * 60 * 1000,
+    errorCode: "too_many_borne_score_claim_starts",
+    message: "Too many borne score claim start requests.",
+    resolveKey: (request) => getClientIp(request),
+  });
+
+  const limitScoreClaimStatusByIp = createRateLimitMiddleware({
+    // Le mobile peut poller le statut du claim ; on limite par IP.
+    keyPrefix: "score-claim-status-ip",
+    maxRequests: 120,
+    windowMs: 60 * 1000,
+    errorCode: "too_many_score_claim_status_requests",
+    message: "Too many score claim status requests.",
+    resolveKey: (request) => getClientIp(request),
+  });
+
+  const limitScoreClaimStatusByCode = createRateLimitMiddleware({
+    // On limite aussi par code pour éviter qu'un même QR soit martelé depuis
+    // plusieurs clients ou onglets.
+    keyPrefix: "score-claim-status-code",
+    maxRequests: 30,
+    windowMs: 60 * 1000,
+    errorCode: "too_many_score_claim_status_requests",
+    message: "Too many score claim status requests for this claim code.",
+    resolveKey: (request) =>
+      readSingleRouteParam(request.params.claimCode) || "missing-claim-code",
+  });
+
+  const limitScoreClaimApproveByIp = createRateLimitMiddleware({
+    // L'approbation rattache un score à un compte utilisateur : c'est plus
+    // sensible qu'une simple lecture de statut.
+    keyPrefix: "score-claim-approve-ip",
+    maxRequests: 20,
+    windowMs: 5 * 60 * 1000,
+    errorCode: "too_many_score_claim_approve_requests",
+    message: "Too many score claim approve requests.",
+    resolveKey: (request) => getClientIp(request),
+  });
+
+  const limitScoreClaimApproveByCode = createRateLimitMiddleware({
+    // Protection complémentaire sur le claim lui-même.
+    keyPrefix: "score-claim-approve-code",
+    maxRequests: 10,
+    windowMs: 5 * 60 * 1000,
+    errorCode: "too_many_score_claim_approve_requests",
+    message: "Too many score claim approve requests for this claim code.",
+    resolveKey: (request) =>
+      String(request.body?.claimCode ?? "missing-claim-code"),
+  });
+
+  app.post(
+    "/api/score-claims/start",
+    limitScoreClaimStart,
+    async (request, response) => {
+      const payload = parseScoreClaimStartPayload(request.body);
+
+      if (env.scoreClaimMode === "remote") {
+        // En mode remote, le backend local du flipper ne crée pas de QR local.
+        // Il délègue au VPS, qui possède la base publique et l'URL scannable.
+        if (!env.globalApiUrl || !env.borneToken) {
+          throw createHttpError(
+            503,
+            "remote_score_claim_not_configured",
+            "Remote score claim mode requires GLOBAL_API_URL and BORNE_TOKEN.",
+          );
+        }
+
+        // En mode borne réelle, la base source de vérité est le VPS.
+        // Le backend local relaie donc le score sans exposer BORNE_TOKEN au frontend.
+        const remoteResult = await remoteScoreClaimStarter({
+          borneToken: env.borneToken,
+          globalApiUrl: env.globalApiUrl,
+          payload,
+        });
+
+        response.status(getScoreClaimStartStatus(remoteResult)).json(remoteResult);
+        return;
+      }
+
+      const session = await getSession(request.headers);
+      const localResult = await startLocalScoreClaim(payload, session);
+
+      response.status(getScoreClaimStartStatus(localResult)).json(localResult);
+    },
+  );
+
+  app.post(
+    "/api/borne/score-claims/start",
+    limitBorneScoreClaimStart,
+    async (request, response) => {
+      if (!env.borneToken) {
+        // Sur le VPS, cette route ne doit pas être ouverte tant que le secret
+        // partagé avec la borne n'est pas configuré.
+        throw createHttpError(
+          503,
+          "borne_token_not_configured",
+          "BORNE_TOKEN is required to accept score claims from a physical cabinet.",
+        );
+      }
+
+      const providedToken = readBearerToken(request.get("authorization"));
+
+      if (!providedToken || !tokensMatch(providedToken, env.borneToken)) {
+        // Le token est le seul droit accordé à la borne : créer un score invité.
+        // Il ne donne jamais accès à une session utilisateur.
+        throw createHttpError(
+          401,
+          "invalid_borne_token",
+          "The physical cabinet token is invalid.",
+        );
+      }
+
+      // Route publique du VPS pour les bornes autorisées.
+      // Elle ne lit volontairement pas la session utilisateur : le joueur
+      // s'authentifie ensuite sur /score-claim pour rattacher ce score.
+      const payload = parseScoreClaimStartPayload(request.body);
+      const localResult = await startLocalScoreClaim(payload, null);
+
+      response.status(getScoreClaimStartStatus(localResult)).json(localResult);
+    },
+  );
+
+  app.get(
+    "/api/score-claims/status/:claimCode",
+    limitScoreClaimStatusByIp,
+    limitScoreClaimStatusByCode,
+    async (request, response) => {
+      const claimCode = readSingleRouteParam(request.params.claimCode);
+
+      assertValidClaimCode(claimCode);
+
+      if (env.scoreClaimMode === "remote") {
+        // En mode borne, le score a été créé sur le VPS. Le backend local sert
+        // uniquement de relais pour que le Playfield/Backglass ne dépendent pas
+        // directement d'une URL publique différente.
+        if (!env.globalApiUrl) {
+          throw createHttpError(
+            503,
+            "remote_score_claim_not_configured",
+            "Remote score claim mode requires GLOBAL_API_URL.",
+          );
+        }
+
+        const remoteResult = await remoteScoreClaimStatusChecker({
+          claimCode,
+          globalApiUrl: env.globalApiUrl,
+        });
+
+        response.status(remoteResult.statusCode).json(remoteResult.body);
+        return;
+      }
+
+      const [scoreClaim] = await db
+        // On joint `games` pour renvoyer au mobile le score exact à afficher
+        // pendant la validation, et `users` pour indiquer si le claim est déjà
+        // attaché à un compte.
+        .select({
+          status: scoreClaimRequests.status,
+          expiresAt: scoreClaimRequests.expiresAt,
+          approvedAt: scoreClaimRequests.approvedAt,
+          userId: scoreClaimRequests.userId,
+          username: users.username,
+          gameId: games.id,
+          finalScore: games.finalScore,
+          playedAt: games.playedAt,
+          playedDurationSeconds: games.playedDurationSeconds,
+        })
+        .from(scoreClaimRequests)
+        .innerJoin(games, eq(scoreClaimRequests.gameId, games.id))
+        .leftJoin(users, eq(scoreClaimRequests.userId, users.id))
+        .where(eq(scoreClaimRequests.claimCode, claimCode))
+        .limit(1);
+
+      if (!scoreClaim) {
+        response.status(404).json({ status: "not_found" });
+        return;
+      }
+
+      const effectiveStatus = await expirePendingScoreClaimIfNeeded(
+        claimCode,
+        scoreClaim.status,
+        scoreClaim.expiresAt,
+      );
+
+      if (effectiveStatus === scoreClaimStatus.expired) {
+        response.status(410).json({ status: "expired" });
+        return;
+      }
+
+      response.json({
+        status: effectiveStatus,
+        user: scoreClaim.userId
+          ? {
+              username: scoreClaim.username,
+            }
+          : null,
+        game: {
+          id: scoreClaim.gameId,
+          finalScore: scoreClaim.finalScore,
+          playedAt: scoreClaim.playedAt.toISOString(),
+          playedDurationSeconds: scoreClaim.playedDurationSeconds,
+        },
+        approvedAt: scoreClaim.approvedAt?.toISOString() ?? null,
+        expiresAt: scoreClaim.expiresAt.toISOString(),
+      });
+    },
+  );
+
+  app.post(
+    "/api/score-claims/approve",
+    limitScoreClaimApproveByIp,
+    limitScoreClaimApproveByCode,
+    async (request, response) => {
+      const claimCode = String(request.body?.claimCode ?? "");
+
+      if (!claimCode) {
+        response.status(400).json({ error: "claim_code_required" });
+        return;
+      }
+
+      assertValidClaimCode(claimCode);
+
+      const session = await getSession(request.headers);
+
+      if (!session) {
+        response.status(401).json({ error: "authentication_required" });
+        return;
+      }
+
+      const approvalResult = await db.transaction(async (tx) => {
+        // On approuve d'abord le claim, puis on rattache la partie.
+        // La transaction garantit qu'aucune requête concurrente ne laisse
+        // un état intermédiaire incohérent.
+        const [approvedClaim] = await tx
+          .update(scoreClaimRequests)
+          .set({
+            status: scoreClaimStatus.approved,
+            userId: session.user.id,
+            approvedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(scoreClaimRequests.claimCode, claimCode),
+              eq(scoreClaimRequests.status, scoreClaimStatus.pending),
+              gt(scoreClaimRequests.expiresAt, new Date()),
+            ),
+          )
+          .returning({
+            gameId: scoreClaimRequests.gameId,
+          });
+
+        if (approvedClaim) {
+          // Le claim est bien en attente et pas expiré : on rattache maintenant
+          // la partie au compte connecté.
+          const [claimedGame] = await tx
+            .update(games)
+            .set({
+              userId: session.user.id,
+            })
+            .where(
+              and(
+                eq(games.id, approvedClaim.gameId),
+                isNull(games.userId),
+              ),
+            )
+            .returning({
+              id: games.id,
+              finalScore: games.finalScore,
+            });
+
+          if (!claimedGame) {
+            throw createHttpError(
+              409,
+              "score_claim_game_already_owned",
+              "The score claim game is already attached to a user.",
+            );
+          }
+
+          return {
+            kind: "approved" as const,
+            game: claimedGame,
+          };
+        }
+
+        const [existingClaim] = await tx
+          // Si l'update précédent n'a rien touché, on relit l'état exact pour
+          // retourner une erreur métier compréhensible au client.
+          .select({
+            status: scoreClaimRequests.status,
+            expiresAt: scoreClaimRequests.expiresAt,
+            gameId: scoreClaimRequests.gameId,
+            finalScore: games.finalScore,
+          })
+          .from(scoreClaimRequests)
+          .innerJoin(games, eq(scoreClaimRequests.gameId, games.id))
+          .where(eq(scoreClaimRequests.claimCode, claimCode))
+          .limit(1);
+
+        if (!existingClaim) {
+          return { kind: "missing" as const };
+        }
+
+        if (
+          existingClaim.status === scoreClaimStatus.pending &&
+          isExpired(existingClaim.expiresAt)
+        ) {
+          await tx
+            .update(scoreClaimRequests)
+            .set({
+              status: scoreClaimStatus.expired,
+            })
+            .where(
+              and(
+                eq(scoreClaimRequests.claimCode, claimCode),
+                eq(scoreClaimRequests.status, scoreClaimStatus.pending),
+              ),
+            );
+
+          return { kind: "expired" as const };
+        }
+
+        if (existingClaim.status === scoreClaimStatus.approved) {
+          return {
+            kind: "already-approved" as const,
+            game: {
+              id: existingClaim.gameId,
+              finalScore: existingClaim.finalScore,
+            },
+          };
+        }
+
+        return { kind: "conflict" as const };
+      });
+
+      if (
+        approvalResult.kind === "approved" ||
+        approvalResult.kind === "already-approved"
+      ) {
+        response.json({
+          status: scoreClaimStatus.approved,
+          game: approvalResult.game,
+        });
+        return;
+      }
+
+      if (approvalResult.kind === "missing") {
+        response.status(404).json({ error: "score_claim_not_found" });
+        return;
+      }
+
+      if (approvalResult.kind === "expired") {
+        response.status(410).json({ error: "score_claim_expired" });
+        return;
+      }
+
+      throw createHttpError(
+        409,
+        "score_claim_approval_conflict",
+        "The score claim request could not be approved safely.",
+      );
+    },
+  );
+}

--- a/backend/src/services/remote-score-claim-client.ts
+++ b/backend/src/services/remote-score-claim-client.ts
@@ -1,0 +1,314 @@
+import type {
+  ScoreClaimStartClaim,
+  ScoreClaimStartGame,
+  ScoreClaimStartPayload,
+  ScoreClaimStartResponse,
+  ScorePersistenceDecision,
+  ScorePersistenceReason,
+} from "./score-claim-service.js";
+
+const claimCodeLength = 32;
+
+type RemoteScoreClaimStartInput = {
+  borneToken: string;
+  fetchImpl?: typeof fetch;
+  globalApiUrl: string;
+  payload: ScoreClaimStartPayload;
+};
+
+type RemoteScoreClaimStatusInput = {
+  claimCode: string;
+  fetchImpl?: typeof fetch;
+  globalApiUrl: string;
+};
+
+export type RemoteScoreClaimStatusResponse = {
+  approvedAt: string | null;
+  expiresAt: string;
+  game: ScoreClaimStartGame;
+  status: "pending" | "approved";
+  user: {
+    username: string | null;
+  } | null;
+};
+
+export type RemoteScoreClaimStatusResult =
+  | {
+      body: RemoteScoreClaimStatusResponse;
+      statusCode: 200;
+    }
+  | {
+      body: { status: "expired" };
+      statusCode: 410;
+    }
+  | {
+      body: { status: "not_found" };
+      statusCode: 404;
+    };
+
+export type RemoteScoreClaimStarter = (
+  input: RemoteScoreClaimStartInput,
+) => Promise<ScoreClaimStartResponse>;
+
+export type RemoteScoreClaimStatusChecker = (
+  input: RemoteScoreClaimStatusInput,
+) => Promise<RemoteScoreClaimStatusResult>;
+
+export class RemoteScoreClaimError extends Error {
+  code: string;
+  status: number;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "RemoteScoreClaimError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isScorePersistenceDecision(value: unknown): value is ScorePersistenceDecision {
+  return value === "discard" || value === "save" || value === "save_and_claimable";
+}
+
+function isScorePersistenceReason(value: unknown): value is ScorePersistenceReason {
+  return (
+    value === "authenticated_user" ||
+    value === "guest_claim_requested" ||
+    value === "guest_score_saved_for_leaderboard" ||
+    value === "guest_score_below_leaderboard_cutoff" ||
+    value === "score_not_significant" ||
+    value === "non_arcade_claim_request"
+  );
+}
+
+function isIsoDateString(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  return !Number.isNaN(Date.parse(value));
+}
+
+function isAbsoluteUrl(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isClaimCodeCharacter(character: string): boolean {
+  const isUppercaseLetter = character >= "A" && character <= "Z";
+  const isLowercaseLetter = character >= "a" && character <= "z";
+  const isDigit = character >= "0" && character <= "9";
+
+  return (
+    isUppercaseLetter ||
+    isLowercaseLetter ||
+    isDigit ||
+    character === "_" ||
+    character === "-"
+  );
+}
+
+function isScoreClaimCode(value: unknown): value is string {
+  if (typeof value !== "string" || value.length !== claimCodeLength) {
+    return false;
+  }
+
+  // Même logique que la validation route backend, sans regex.
+  // Le QR code ne doit jamais être généré depuis un code reçu mais invalide.
+  return [...value].every(isClaimCodeCharacter);
+}
+
+function isScoreClaimStartGame(value: unknown): value is ScoreClaimStartGame {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    Number.isInteger(value.id) &&
+    typeof value.finalScore === "number" &&
+    Number.isInteger(value.finalScore) &&
+    typeof value.playedDurationSeconds === "number" &&
+    Number.isInteger(value.playedDurationSeconds) &&
+    isIsoDateString(value.playedAt)
+  );
+}
+
+function isScoreClaimStartClaim(value: unknown): value is ScoreClaimStartClaim {
+  return (
+    isRecord(value) &&
+    isScoreClaimCode(value.claimCode) &&
+    isIsoDateString(value.expiresAt) &&
+    value.status === "pending" &&
+    isAbsoluteUrl(value.verificationUrl)
+  );
+}
+
+function isScoreClaimStatusUser(
+  value: unknown,
+): value is RemoteScoreClaimStatusResponse["user"] {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      (typeof value.username === "string" || value.username === null))
+  );
+}
+
+function isScoreClaimStatusResponse(
+  value: unknown,
+): value is RemoteScoreClaimStatusResponse {
+  return (
+    isRecord(value) &&
+    (value.status === "pending" || value.status === "approved") &&
+    isIsoDateString(value.expiresAt) &&
+    (typeof value.approvedAt === "string"
+      ? isIsoDateString(value.approvedAt)
+      : value.approvedAt === null) &&
+    isScoreClaimStartGame(value.game) &&
+    isScoreClaimStatusUser(value.user)
+  );
+}
+
+function isScoreClaimStartResponse(value: unknown): value is ScoreClaimStartResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (!isScorePersistenceDecision(value.decision) || !isScorePersistenceReason(value.reason)) {
+    return false;
+  }
+
+  const gameIsValid = value.game === null || isScoreClaimStartGame(value.game);
+  const claimIsValid = value.claim === null || isScoreClaimStartClaim(value.claim);
+
+  return gameIsValid && claimIsValid;
+}
+
+async function readJsonResponse(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function startRemoteScoreClaim({
+  borneToken,
+  fetchImpl = fetch,
+  globalApiUrl,
+  payload,
+}: RemoteScoreClaimStartInput): Promise<ScoreClaimStartResponse> {
+  const endpoint = new URL("/api/borne/score-claims/start", globalApiUrl);
+  let response: Response;
+
+  try {
+    response = await fetchImpl(endpoint, {
+      body: JSON.stringify(payload),
+      headers: {
+        Authorization: `Bearer ${borneToken}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+  } catch {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_unreachable",
+      "The remote score claim API could not be reached.",
+    );
+  }
+
+  const responseBody = await readJsonResponse(response);
+
+  if (!response.ok) {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_failed",
+      "The remote score claim API rejected the score.",
+    );
+  }
+
+  // Le backend local relaie cette réponse au backglass.
+  // On valide donc le contrat reçu du VPS avant d'afficher un QR code public.
+  if (!isScoreClaimStartResponse(responseBody)) {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_invalid_response",
+      "The remote score claim API returned an invalid payload.",
+    );
+  }
+
+  return responseBody;
+}
+
+export async function getRemoteScoreClaimStatus({
+  claimCode,
+  fetchImpl = fetch,
+  globalApiUrl,
+}: RemoteScoreClaimStatusInput): Promise<RemoteScoreClaimStatusResult> {
+  const endpoint = new URL(
+    `/api/score-claims/status/${encodeURIComponent(claimCode)}`,
+    globalApiUrl,
+  );
+  let response: Response;
+
+  try {
+    response = await fetchImpl(endpoint, {
+      method: "GET",
+    });
+  } catch {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_status_unreachable",
+      "The remote score claim status API could not be reached.",
+    );
+  }
+
+  const responseBody = await readJsonResponse(response);
+
+  // Ces deux statuts sont volontairement relayés tels quels : ils décrivent un
+  // état métier attendu et permettent au front local d'arrêter son polling.
+  if (response.status === 404) {
+    return {
+      body: { status: "not_found" },
+      statusCode: 404,
+    };
+  }
+
+  if (response.status === 410) {
+    return {
+      body: { status: "expired" },
+      statusCode: 410,
+    };
+  }
+
+  if (!response.ok) {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_status_failed",
+      "The remote score claim status API rejected the status lookup.",
+    );
+  }
+
+  if (!isScoreClaimStatusResponse(responseBody)) {
+    throw new RemoteScoreClaimError(
+      502,
+      "remote_score_claim_status_invalid_response",
+      "The remote score claim status API returned an invalid payload.",
+    );
+  }
+
+  return {
+    body: responseBody,
+    statusCode: 200,
+  };
+}

--- a/backend/src/services/score-claim-service.ts
+++ b/backend/src/services/score-claim-service.ts
@@ -12,6 +12,8 @@ export type ScorePersistenceReason =
 
 export type AppMode = "web" | "arcade";
 
+export type ScoreClaimRequestStatus = "pending";
+
 export type ScorePersistenceEvaluationInput = {
   finalScore: number;
   isAuthenticated: boolean;
@@ -19,6 +21,34 @@ export type ScorePersistenceEvaluationInput = {
   playedDurationSeconds: number;
   requestClaim: boolean;
   wouldEnterLeaderboard: boolean;
+};
+
+export type ScoreClaimStartPayload = {
+  finalScore: number;
+  mode: AppMode;
+  playedDurationSeconds: number;
+  requestClaim: boolean;
+};
+
+export type ScoreClaimStartGame = {
+  finalScore: number;
+  id: number;
+  playedAt: string;
+  playedDurationSeconds: number;
+};
+
+export type ScoreClaimStartClaim = {
+  claimCode: string;
+  expiresAt: string;
+  status: ScoreClaimRequestStatus;
+  verificationUrl: string;
+};
+
+export type ScoreClaimStartResponse = {
+  claim: ScoreClaimStartClaim | null;
+  decision: ScorePersistenceDecision;
+  game: ScoreClaimStartGame | null;
+  reason: ScorePersistenceReason;
 };
 
 export const SCORE_CLAIM_TTL_MS = 120 * 1000;

--- a/backend/tests/helpers/create-test-app.ts
+++ b/backend/tests/helpers/create-test-app.ts
@@ -4,15 +4,22 @@ import { createAuth } from "../../src/auth.js";
 import type { DatabaseClient } from "../../src/db/client.js";
 import { createTestAuthHarness } from "./test-auth.js";
 
-export function createTestApp(db: DatabaseClient) {
-  const auth = createAuth({ db, env });
+export function createTestApp(
+  db: DatabaseClient,
+  options: { envOverrides?: Partial<typeof env> } = {},
+) {
+  const testEnv = {
+    ...env,
+    ...options.envOverrides,
+  };
+  const auth = createAuth({ db, env: testEnv });
   const authHarness = createTestAuthHarness();
 
   return createApp({
     auth,
     authRouteHandler: authHarness.authRouteHandler,
     db,
-    env,
+    env: testEnv,
     getSession: authHarness.getSession,
   });
 }

--- a/backend/tests/integration/app.injected-routes.test.ts
+++ b/backend/tests/integration/app.injected-routes.test.ts
@@ -5,6 +5,10 @@ import { createApp, resetRateLimitStoreForTests } from "../../src/app.js";
 import type { AuthInstance } from "../../src/auth.js";
 import type { DatabaseClient } from "../../src/db/client.js";
 import { env } from "../../src/env.js";
+import type {
+  RemoteScoreClaimStatusChecker,
+  RemoteScoreClaimStarter,
+} from "../../src/services/remote-score-claim-client.js";
 
 type AppSession = {
   session: {
@@ -23,6 +27,8 @@ function createRouteTestApp(
     db?: Partial<DatabaseClient>;
     envOverrides?: Partial<typeof env>;
     getSession?: (headers: Record<string, unknown>) => Promise<AppSession | null>;
+    remoteScoreClaimStatusChecker?: RemoteScoreClaimStatusChecker;
+    remoteScoreClaimStarter?: RemoteScoreClaimStarter;
   } = {},
 ) {
   return createApp({
@@ -43,6 +49,16 @@ function createRouteTestApp(
     getSession:
       options.getSession ??
       (async () => null),
+    remoteScoreClaimStatusChecker:
+      options.remoteScoreClaimStatusChecker ??
+      (async () => {
+        throw new Error("remote score claim status checker not configured in test");
+      }),
+    remoteScoreClaimStarter:
+      options.remoteScoreClaimStarter ??
+      (async () => {
+        throw new Error("remote score claim starter not configured in test");
+      }),
   });
 }
 
@@ -180,6 +196,132 @@ describe("app injected routes", () => {
     expect(limitedResponse.status).toBe(429);
     expect(limitedResponse.body).toEqual({
       error: "too_many_score_claim_starts",
+    });
+  });
+
+  it("relays score claim starts to the remote VPS when remote mode is enabled", async () => {
+    const remoteScoreClaimStarter = vi.fn(async () => ({
+      claim: {
+        claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        status: "pending" as const,
+        verificationUrl: "https://scores.example.test/score-claim?code=ABCDEFGHIJKLMNOPQRSTUVWX12345678&mode=arcade",
+      },
+      decision: "save_and_claimable" as const,
+      game: {
+        finalScore: 654321,
+        id: 91,
+        playedAt: new Date().toISOString(),
+        playedDurationSeconds: 95,
+      },
+      reason: "guest_claim_requested" as const,
+    }));
+    const app = createRouteTestApp({
+      envOverrides: {
+        borneToken: "cabinet-secret",
+        globalApiUrl: "https://scores.example.test/",
+        scoreClaimMode: "remote",
+      },
+      remoteScoreClaimStarter,
+    });
+
+    const response = await request(app)
+      .post("/api/score-claims/start")
+      .send({
+        finalScore: 654321,
+        mode: "arcade",
+        playedDurationSeconds: 95,
+        requestClaim: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.claim.verificationUrl).toBe(
+      "https://scores.example.test/score-claim?code=ABCDEFGHIJKLMNOPQRSTUVWX12345678&mode=arcade",
+    );
+    expect(remoteScoreClaimStarter).toHaveBeenCalledWith({
+      borneToken: "cabinet-secret",
+      globalApiUrl: "https://scores.example.test/",
+      payload: {
+        finalScore: 654321,
+        mode: "arcade",
+        playedDurationSeconds: 95,
+        requestClaim: true,
+      },
+    });
+  });
+
+  it("returns 503 instead of creating a broken QR when remote settings are incomplete", async () => {
+    const app = createRouteTestApp({
+      envOverrides: {
+        borneToken: undefined,
+        globalApiUrl: "https://scores.example.test/",
+        scoreClaimMode: "remote",
+      },
+    });
+
+    const response = await request(app)
+      .post("/api/score-claims/start")
+      .send({
+        finalScore: 654321,
+        mode: "arcade",
+        playedDurationSeconds: 95,
+        requestClaim: true,
+      });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      error: "remote_score_claim_not_configured",
+    });
+  });
+
+  it("relays score claim status lookups to the remote VPS when remote mode is enabled", async () => {
+    const claimCode = "ABCDEFGHIJKLMNOPQRSTUVWX12345678";
+    const playedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const remoteScoreClaimStatusChecker = vi.fn(async () => ({
+      body: {
+        approvedAt: null,
+        expiresAt,
+        game: {
+          finalScore: 654321,
+          id: 91,
+          playedAt,
+          playedDurationSeconds: 95,
+        },
+        status: "pending" as const,
+        user: null,
+      },
+      statusCode: 200 as const,
+    }));
+    const app = createRouteTestApp({
+      envOverrides: {
+        borneToken: "cabinet-secret",
+        globalApiUrl: "https://scores.example.test/",
+        scoreClaimMode: "remote",
+      },
+      remoteScoreClaimStatusChecker,
+    });
+
+    const response = await request(app).get(
+      `/api/score-claims/status/${claimCode}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      approvedAt: null,
+      expiresAt,
+      game: {
+        finalScore: 654321,
+        id: 91,
+        playedAt,
+        playedDurationSeconds: 95,
+      },
+      status: "pending",
+      user: null,
+    });
+    expect(remoteScoreClaimStatusChecker).toHaveBeenCalledWith({
+      claimCode,
+      globalApiUrl: "https://scores.example.test/",
     });
   });
 

--- a/backend/tests/integration/score-claims.start-status.test.ts
+++ b/backend/tests/integration/score-claims.start-status.test.ts
@@ -103,6 +103,74 @@ describe("score-claims integration - start and status", () => {
     expect(response.body.claim.verificationUrl).toContain("mode=arcade");
   });
 
+  it("rejects borne score starts without the configured bearer token", async () => {
+    const publicApp = createTestApp(db, {
+      envOverrides: {
+        borneToken: "cabinet-secret",
+        frontendUrl: "https://scores.example.test/",
+      },
+    });
+
+    const response = await request(publicApp)
+      .post("/api/borne/score-claims/start")
+      .send({
+        finalScore: 123456,
+        mode: "arcade",
+        playedDurationSeconds: 95,
+        requestClaim: true,
+      });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      error: "invalid_borne_token",
+    });
+  });
+
+  it("creates a public claim from an authorized borne without a user session", async () => {
+    const publicApp = createTestApp(db, {
+      envOverrides: {
+        borneToken: "cabinet-secret",
+        frontendUrl: "https://scores.example.test/",
+      },
+    });
+
+    const response = await request(publicApp)
+      .post("/api/borne/score-claims/start")
+      .set("authorization", "Bearer cabinet-secret")
+      .send({
+        finalScore: 234567,
+        mode: "arcade",
+        playedDurationSeconds: 95,
+        requestClaim: true,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      decision: "save_and_claimable",
+      reason: "guest_claim_requested",
+      game: {
+        finalScore: 234567,
+        playedDurationSeconds: 95,
+      },
+      claim: {
+        status: "pending",
+      },
+    });
+    expect(response.body.claim.verificationUrl).toContain(
+      "https://scores.example.test/score-claim?code=",
+    );
+
+    const [persistedGame] = await db
+      .select({
+        userId: games.userId,
+      })
+      .from(games)
+      .where(eq(games.id, response.body.game.id))
+      .limit(1);
+
+    expect(persistedGame?.userId).toBeNull();
+  });
+
   it.each([
     ["float number", { finalScore: 12.5, mode: "arcade", playedDurationSeconds: 95, requestClaim: true }, "finalScore_invalid"],
     ["partial string", { finalScore: "123abc", mode: "arcade", playedDurationSeconds: 95, requestClaim: true }, "finalScore_invalid"],

--- a/backend/tests/unit/auth.test.ts
+++ b/backend/tests/unit/auth.test.ts
@@ -90,18 +90,25 @@ describe("auth configuration", () => {
     });
 
     const options = mocks.betterAuth.mock.calls.at(-1)?.[0] as {
-      socialProviders: Record<string, unknown>;
+      socialProviders: {
+        github: {
+          clientId: string;
+          clientSecret: string;
+        };
+        google: {
+          clientId: string;
+          clientSecret: string;
+        };
+      };
     };
 
-    expect(options.socialProviders).toEqual({
-      github: {
-        clientId: "github-client-id",
-        clientSecret: "github-client-secret",
-      },
-      google: {
-        clientId: "google-client-id",
-        clientSecret: "google-client-secret",
-      },
+    expect(options.socialProviders.github).toMatchObject({
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+    });
+    expect(options.socialProviders.google).toEqual({
+      clientId: "google-client-id",
+      clientSecret: "google-client-secret",
     });
   });
 

--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -8,10 +8,13 @@ const envKeys = [
   "FRONTEND_URL",
   "GITHUB_CLIENT_ID",
   "GITHUB_CLIENT_SECRET",
+  "GLOBAL_API_URL",
   "GOOGLE_CLIENT_ID",
   "GOOGLE_CLIENT_SECRET",
+  "BORNE_TOKEN",
   "NODE_ENV",
   "PORT",
+  "SCORE_CLAIM_MODE",
   "TRUST_PROXY",
 ] as const;
 
@@ -122,6 +125,57 @@ describe("env", () => {
     const { env } = await importEnv(validEnv());
 
     expect(env.trustProxy).toBe(false);
+  });
+
+  it("defaults score claim mode to local", async () => {
+    const { env } = await importEnv(validEnv());
+
+    expect(env.scoreClaimMode).toBe("local");
+    expect(env.globalApiUrl).toBeUndefined();
+    expect(env.borneToken).toBeUndefined();
+  });
+
+  it("requires remote score claim settings when remote mode is enabled", async () => {
+    await expect(
+      importEnv(
+        validEnv({
+          SCORE_CLAIM_MODE: "remote",
+        }),
+      ),
+    ).rejects.toThrow("GLOBAL_API_URL is required when SCORE_CLAIM_MODE=remote.");
+
+    await expect(
+      importEnv(
+        validEnv({
+          GLOBAL_API_URL: "https://scores.example.test",
+          SCORE_CLAIM_MODE: "remote",
+        }),
+      ),
+    ).rejects.toThrow("BORNE_TOKEN is required when SCORE_CLAIM_MODE=remote.");
+  });
+
+  it("parses remote score claim settings", async () => {
+    const { env } = await importEnv(
+      validEnv({
+        BORNE_TOKEN: "cabinet-secret",
+        GLOBAL_API_URL: "https://scores.example.test/api-root",
+        SCORE_CLAIM_MODE: "remote",
+      }),
+    );
+
+    expect(env.scoreClaimMode).toBe("remote");
+    expect(env.globalApiUrl).toBe("https://scores.example.test/api-root");
+    expect(env.borneToken).toBe("cabinet-secret");
+  });
+
+  it("rejects invalid score claim mode", async () => {
+    await expect(
+      importEnv(
+        validEnv({
+          SCORE_CLAIM_MODE: "public",
+        }),
+      ),
+    ).rejects.toThrow("SCORE_CLAIM_MODE must be `local` or `remote`.");
   });
 
   it.each(["abc", "1.5", "1proxy", "-1"])(

--- a/backend/tests/unit/remote-score-claim-client.test.ts
+++ b/backend/tests/unit/remote-score-claim-client.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RemoteScoreClaimError,
+  getRemoteScoreClaimStatus,
+  startRemoteScoreClaim,
+} from "../../src/services/remote-score-claim-client.js";
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+    ...init,
+  });
+}
+
+function expectInvalidRemotePayload(fetchImpl: typeof fetch) {
+  return expect(
+    startRemoteScoreClaim({
+      borneToken: "cabinet-secret",
+      fetchImpl,
+      globalApiUrl: "https://scores.example.test",
+      payload: validPayload,
+    }),
+  ).rejects.toMatchObject({
+    code: "remote_score_claim_invalid_response",
+    status: 502,
+  } satisfies Partial<RemoteScoreClaimError>);
+}
+
+const validPayload = {
+  finalScore: 123456,
+  mode: "arcade" as const,
+  playedDurationSeconds: 95,
+  requestClaim: true,
+};
+
+const validResponse = {
+  claim: {
+    claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    status: "pending",
+    verificationUrl: "https://scores.example.test/score-claim?code=abc&mode=arcade",
+  },
+  decision: "save_and_claimable",
+  game: {
+    finalScore: 123456,
+    id: 42,
+    playedAt: new Date().toISOString(),
+    playedDurationSeconds: 95,
+  },
+  reason: "guest_claim_requested",
+} as const;
+
+const validStatusResponse = {
+  approvedAt: null,
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  game: {
+    finalScore: 123456,
+    id: 42,
+    playedAt: new Date().toISOString(),
+    playedDurationSeconds: 95,
+  },
+  status: "pending",
+  user: null,
+} as const;
+
+describe("remote-score-claim-client", () => {
+  it("posts the score to the VPS borne endpoint with the bearer token", async () => {
+    const fetchImpl = vi.fn(async () => createJsonResponse(validResponse));
+
+    const response = await startRemoteScoreClaim({
+      borneToken: "cabinet-secret",
+      fetchImpl,
+      globalApiUrl: "https://scores.example.test",
+      payload: validPayload,
+    });
+
+    expect(response).toEqual(validResponse);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL("https://scores.example.test/api/borne/score-claims/start"),
+      expect.objectContaining({
+        body: JSON.stringify(validPayload),
+        headers: {
+          Authorization: "Bearer cabinet-secret",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+  });
+
+  it("maps network failures to a 502 integration error", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    await expect(
+      startRemoteScoreClaim({
+        borneToken: "cabinet-secret",
+        fetchImpl,
+        globalApiUrl: "https://scores.example.test",
+        payload: validPayload,
+      }),
+    ).rejects.toMatchObject({
+      code: "remote_score_claim_unreachable",
+      status: 502,
+    } satisfies Partial<RemoteScoreClaimError>);
+  });
+
+  it("maps non-successful VPS responses to a 502 integration error", async () => {
+    const fetchImpl = vi.fn(async () =>
+      createJsonResponse({ error: "invalid_borne_token" }, { status: 401 }),
+    );
+
+    await expect(
+      startRemoteScoreClaim({
+        borneToken: "cabinet-secret",
+        fetchImpl,
+        globalApiUrl: "https://scores.example.test",
+        payload: validPayload,
+      }),
+    ).rejects.toMatchObject({
+      code: "remote_score_claim_failed",
+      status: 502,
+    } satisfies Partial<RemoteScoreClaimError>);
+  });
+
+  it("rejects malformed VPS responses before a QR code can be displayed", async () => {
+    const fetchImpl = vi.fn(async () =>
+      createJsonResponse({
+        claim: {
+          verificationUrl: "not-an-url",
+        },
+        decision: "save_and_claimable",
+        game: null,
+        reason: "guest_claim_requested",
+      }),
+    );
+
+    await expectInvalidRemotePayload(fetchImpl);
+  });
+
+  it("rejects invalid claim codes received from the VPS", async () => {
+    const fetchImpl = vi.fn(async () =>
+      createJsonResponse({
+        ...validResponse,
+        claim: {
+          ...validResponse.claim,
+          claimCode: "not-a-valid-code",
+        },
+      }),
+    );
+
+    await expectInvalidRemotePayload(fetchImpl);
+  });
+
+  it("rejects unreadable JSON responses from the VPS", async () => {
+    const fetchImpl = vi.fn(async () => new Response("not-json", { status: 200 }));
+
+    await expectInvalidRemotePayload(fetchImpl);
+  });
+
+  it("rejects non-object VPS responses", async () => {
+    const fetchImpl = vi.fn(async () => createJsonResponse(null));
+
+    await expectInvalidRemotePayload(fetchImpl);
+  });
+
+  it("rejects unknown persistence decisions or reasons from the VPS", async () => {
+    const fetchImpl = vi.fn(async () =>
+      createJsonResponse({
+        ...validResponse,
+        decision: "unknown",
+      }),
+    );
+
+    await expectInvalidRemotePayload(fetchImpl);
+  });
+
+  it("gets score claim status from the VPS public status endpoint", async () => {
+    const fetchImpl = vi.fn(async () => createJsonResponse(validStatusResponse));
+
+    const result = await getRemoteScoreClaimStatus({
+      claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+      fetchImpl,
+      globalApiUrl: "https://scores.example.test",
+    });
+
+    expect(result).toEqual({
+      body: validStatusResponse,
+      statusCode: 200,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "https://scores.example.test/api/score-claims/status/ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+      ),
+      {
+        method: "GET",
+      },
+    );
+  });
+
+  it("relays expected remote status terminal responses", async () => {
+    const notFoundFetch = vi.fn(async () =>
+      createJsonResponse({ status: "not_found" }, { status: 404 }),
+    );
+    const expiredFetch = vi.fn(async () =>
+      createJsonResponse({ status: "expired" }, { status: 410 }),
+    );
+
+    await expect(
+      getRemoteScoreClaimStatus({
+        claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+        fetchImpl: notFoundFetch,
+        globalApiUrl: "https://scores.example.test",
+      }),
+    ).resolves.toEqual({
+      body: { status: "not_found" },
+      statusCode: 404,
+    });
+
+    await expect(
+      getRemoteScoreClaimStatus({
+        claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+        fetchImpl: expiredFetch,
+        globalApiUrl: "https://scores.example.test",
+      }),
+    ).resolves.toEqual({
+      body: { status: "expired" },
+      statusCode: 410,
+    });
+  });
+
+  it("rejects malformed remote status responses", async () => {
+    const fetchImpl = vi.fn(async () =>
+      createJsonResponse({
+        ...validStatusResponse,
+        game: {
+          id: "invalid",
+        },
+      }),
+    );
+
+    await expect(
+      getRemoteScoreClaimStatus({
+        claimCode: "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+        fetchImpl,
+        globalApiUrl: "https://scores.example.test",
+      }),
+    ).rejects.toMatchObject({
+      code: "remote_score_claim_status_invalid_response",
+      status: 502,
+    } satisfies Partial<RemoteScoreClaimError>);
+  });
+});

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -34,6 +34,12 @@ services:
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - FRONTEND_ORIGINS=${FRONTEND_ORIGINS:-http://localhost:5173}
+      # Score claim peut fonctionner en local ou relayer vers le VPS.
+      # Ces variables doivent être injectées dans le backend Docker ; sinon
+      # le backend ignore le .env racine et repasse en mode local par défaut.
+      - SCORE_CLAIM_MODE=${SCORE_CLAIM_MODE:-local}
+      - GLOBAL_API_URL=${GLOBAL_API_URL:-}
+      - BORNE_TOKEN=${BORNE_TOKEN:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}

--- a/deploy/docker-compose.vps.yml
+++ b/deploy/docker-compose.vps.yml
@@ -1,0 +1,115 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: pinball-postgres
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:?POSTGRES_DB is required}
+      - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER is required}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+
+  migrate:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    command: [ "pnpm", "run", "db:migrate" ]
+    environment:
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:?BETTER_AUTH_URL is required}
+      - FRONTEND_URL=${FRONTEND_URL:?FRONTEND_URL is required}
+      - FRONTEND_ORIGINS=${FRONTEND_ORIGINS:?FRONTEND_ORIGINS is required}
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+      - SCORE_CLAIM_MODE=${SCORE_CLAIM_MODE:?SCORE_CLAIM_MODE is required}
+      - GLOBAL_API_URL=${GLOBAL_API_URL:-}
+      - BORNE_TOKEN=${BORNE_TOKEN:?BORNE_TOKEN is required}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  backend:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    # Le backend n'est pas exposé publiquement : Nginx le contacte en local.
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:?BETTER_AUTH_URL is required}
+      - FRONTEND_URL=${FRONTEND_URL:?FRONTEND_URL is required}
+      - FRONTEND_ORIGINS=${FRONTEND_ORIGINS:?FRONTEND_ORIGINS is required}
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+      - SCORE_CLAIM_MODE=${SCORE_CLAIM_MODE:?SCORE_CLAIM_MODE is required}
+      - GLOBAL_API_URL=${GLOBAL_API_URL:-}
+      - BORNE_TOKEN=${BORNE_TOKEN:?BORNE_TOKEN is required}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: always
+
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+      args:
+        # Le VPS sert uniquement l'interface publique : pas de jeu 3D ni MQTT.
+        - VITE_APP_TARGET=public
+        - VITE_API_URL=${VITE_API_URL:-}
+    # Nginx expose HTTPS publiquement et proxy vers ce port local.
+    ports:
+      - "127.0.0.1:8080:80"
+    # Le frontend Nginx reference le service `backend` dans sa configuration.
+    # On attend donc que le backend soit lance pour eviter un crash Nginx au
+    # demarrage lorsque le nom DNS Docker `backend` n'existe pas encore.
+    depends_on:
+      backend:
+        condition: service_started
+    restart: always
+
+  mosquitto:
+    profiles:
+      - mqtt
+    image: eclipse-mosquitto:2.0.18
+    container_name: mosquitto
+    environment:
+      - MQTT_USERNAME=${MQTT_USERNAME:?MQTT_USERNAME is required}
+      - MQTT_PASSWORD=${MQTT_PASSWORD:?MQTT_PASSWORD is required}
+    # Service optionnel côté VPS : le flipper physique gère normalement MQTT localement.
+    entrypoint: >
+      sh -c "touch /mosquitto/config/password_file.txt &&
+             mosquitto_passwd -b /mosquitto/config/password_file.txt $$MQTT_USERNAME $$MQTT_PASSWORD &&
+             chown 1883:1883 /mosquitto/config/password_file.txt &&
+             chmod 600 /mosquitto/config/password_file.txt &&
+             echo 'MQTT user created' &&
+             exec mosquitto -c /mosquitto/config/mosquitto.conf"
+    ports:
+      - "1883:1883"
+      - "9001:9001"
+    volumes:
+      - ../mqtt/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - mosquitto_data:/mosquitto/data
+      - mosquitto_log:/mosquitto/log
+    restart: always
+
+volumes:
+  postgres_data:
+  mosquitto_data:
+  mosquitto_log:

--- a/docs/score-claim-vps.md
+++ b/docs/score-claim-vps.md
@@ -1,0 +1,102 @@
+# Score claim avec VPS
+
+## Objectif
+
+Le flipper peut rester en local pour les écrans (`playfield`, `backglass`, `dmd`), mais le QR code doit pointer vers une URL publique. Un téléphone ne peut pas ouvrir `localhost` du flipper : pour lui, `localhost` désigne le téléphone lui-même.
+
+## Flux retenu
+
+1. Le front local du flipper termine une partie et appelle son backend local sur `/api/score-claims/start`.
+2. Si `SCORE_CLAIM_MODE=local`, le backend garde le comportement historique et écrit dans sa base locale.
+3. Si `SCORE_CLAIM_MODE=remote`, le backend local relaie le score vers le VPS sur `/api/borne/score-claims/start`.
+4. Le backend local ajoute `Authorization: Bearer <BORNE_TOKEN>` à l'appel server-to-server.
+5. Le VPS vérifie `BORNE_TOKEN`, écrit le score dans sa base PostgreSQL, crée le `claimCode`, puis renvoie une `verificationUrl` publique.
+6. Le backglass local affiche le QR code avec cette `verificationUrl`.
+7. Le téléphone ouvre le VPS, l'utilisateur se connecte, puis le VPS rattache le score au compte.
+
+## Source de vérité
+
+En mode remote, la base de données source de vérité pour `games`, `users` et `score_claim_requests` est celle du VPS. La base locale du flipper ne doit pas servir à valider un QR code public.
+
+## Frontend public VPS
+
+Le VPS ne doit pas charger le jeu complet. Son build frontend est ciblé avec
+`VITE_APP_TARGET=public` et expose uniquement les pages utiles au téléphone :
+
+- `/` : accueil public minimal.
+- `/login` : connexion ou création de compte.
+- `/score-claim?code=...` : rattachement du score après scan QR.
+- `/dashboard` : espace utilisateur authentifié.
+
+Les pages `/playfield`, `/backglass` et `/dmd` restent réservées au flipper
+local. Le build public ne monte pas `MqttProvider`, ce qui évite les erreurs
+`Mixed Content` provoquées par un WebSocket MQTT `ws://` depuis une page HTTPS.
+
+La route `/score-claim` n'est pas mise en avant dans la navigation. Sans
+paramètre `code`, elle ne permet aucune action de sauvegarde : le score doit
+toujours venir d'un claim créé par le backend VPS.
+
+## Variables côté flipper
+
+```env
+VITE_APP_TARGET=flipper
+SCORE_CLAIM_MODE=remote
+GLOBAL_API_URL=https://votre-vps.example
+BORNE_TOKEN=secret_long_et_aleatoire
+VITE_API_URL=http://localhost:3000
+```
+
+`BORNE_TOKEN` reste côté backend local. Il ne doit jamais être préfixé par `VITE_`, sinon il serait injecté dans le bundle frontend.
+
+## Variables côté VPS
+
+```env
+SCORE_CLAIM_MODE=local
+FRONTEND_URL=https://votre-vps.example
+BETTER_AUTH_URL=https://votre-vps.example
+FRONTEND_ORIGINS=https://votre-vps.example
+BORNE_TOKEN=le_meme_secret_que_la_borne
+POSTGRES_DB=pinball_db
+POSTGRES_USER=pinball_user
+POSTGRES_PASSWORD=secret_long_et_aleatoire
+BETTER_AUTH_SECRET=secret_long_et_aleatoire
+```
+
+Le VPS utilise `SCORE_CLAIM_MODE=local` car il écrit dans sa propre base. Il expose en plus la route sécurisée `/api/borne/score-claims/start` pour recevoir les scores des bornes autorisées.
+
+Le build public VPS force `VITE_APP_TARGET=public` directement dans
+`deploy/docker-compose.vps.yml`. Il ne faut pas définir `VITE_API_URL` sur
+`localhost` côté VPS : sans valeur explicite, le frontend appelle sa propre
+origine HTTPS et Nginx relaie `/api` vers le backend Docker.
+
+Le `.env` du VPS est maintenu directement sur le serveur et n'est pas écrasé par
+la CI. Les secrets réels ne doivent pas être versionnés dans le dépôt.
+
+## Réseau Docker côté VPS
+
+Le reverse proxy Nginx du VPS est le seul point d'entrée public HTTP/HTTPS :
+
+- Nginx sert `https://votre-vps.example`.
+- Le VPS doit être lancé avec `deploy/docker-compose.vps.yml`.
+- Le frontend Docker écoute seulement sur `127.0.0.1:8080`.
+- Le backend Docker écoute seulement sur `127.0.0.1:3000`.
+- PostgreSQL n'est pas publié sur le host : seul le réseau Docker interne y accède.
+
+`deploy/docker-compose.yml` reste dédié au flipper physique via `fliphetic.toml`.
+Ce fichier build le jeu complet avec `VITE_APP_TARGET=flipper`, expose les écrans
+attendus par la borne et garde Mosquitto actif.
+
+Mosquitto n'est pas démarré par défaut dans `deploy/docker-compose.vps.yml`. Il est
+placé sous le profil Docker `mqtt`, car le VPS public n'a pas besoin de piloter
+la borne physique. Si un jour ce service redevient nécessaire côté serveur, il
+faudra l'activer explicitement avec `--profile mqtt` et sécuriser l'exposition
+des ports.
+
+## Sécurité
+
+- Le QR code ne contient qu'un `claimCode` temporaire, jamais un secret.
+- `BORNE_TOKEN` est transmis uniquement de backend à backend.
+- La route borne refuse les requêtes sans `Authorization: Bearer ...`.
+- L'utilisateur doit être authentifié avant de rattacher le score.
+- Le claim expire et ne peut être approuvé qu'une seule fois.
+- Si le VPS est indisponible, le backend local renvoie une erreur : le backglass ne doit pas afficher de faux QR code.

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,5 +1,7 @@
 node_modules
 .pnpm-store
+.vite
+coverage
 dist
 .git
 .env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,12 +11,18 @@ COPY . .
 
 # --- AJOUT CRUCIAL ICI ---
 # On déclare que le Dockerfile va recevoir ces arguments depuis le docker-compose
+ARG VITE_APP_TARGET
+ARG VITE_API_URL
 ARG VITE_MQTT_USERNAME
 ARG VITE_MQTT_PASSWORD
+ARG VITE_MQTT_URL
 
 # On les transforme en variables d'environnement pour que Vite puisse les lire
+ENV VITE_APP_TARGET=$VITE_APP_TARGET
+ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_MQTT_USERNAME=$VITE_MQTT_USERNAME
 ENV VITE_MQTT_PASSWORD=$VITE_MQTT_PASSWORD
+ENV VITE_MQTT_URL=$VITE_MQTT_URL
 # -------------------------
 
 RUN pnpm build

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,27 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /api/ {
+        # En production borne, le navigateur appelle la même origine que le
+        # frontend. Nginx relaie ensuite vers le backend Docker interne, ce qui
+        # évite les problèmes CORS et les ambiguïtés autour de `localhost:3000`.
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Cache pour les fichiers statiques (assets 3D, sons, images)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|glb|gltf|mp3|wav)$ {
         expires 1y;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,25 @@
-import { Route, Routes } from "react-router-dom";
+import { lazy, Suspense } from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import AuthGuard from "./components/auth/AuthGuard";
-import Backglass from "./pages/Backglass";
 import Dashboard from "./pages/Dashboard";
-import DMD from "./pages/DMD";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
-import Playfield from "./pages/Playfield";
 import ScoreClaim from "./pages/ScoreClaim";
 
-function App() {
+// Cette constante utilise directement `import.meta.env` pour que Vite/Rollup
+// puisse supprimer le chunk `FlipperApp` du build public VPS.
+const shouldLoadFlipperApp = import.meta.env.VITE_APP_TARGET !== "public";
+const FlipperApp = shouldLoadFlipperApp
+  ? lazy(() => import("./FlipperApp"))
+  : null;
+
+function PublicApp() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
       <Route path="/score-claim" element={<ScoreClaim />} />
-      <Route path="/playfield" element={<Playfield />} />
       <Route
         path="/dashboard"
         element={
@@ -24,9 +28,24 @@ function App() {
           </AuthGuard>
         }
       />
-      <Route path="/backglass" element={<Backglass />} />
-      <Route path="/dmd" element={<DMD />} />
+      <Route path="*" element={<Navigate replace to="/" />} />
     </Routes>
+  );
+}
+
+function App() {
+  if (FlipperApp) {
+    return (
+      <Suspense fallback={null}>
+        <FlipperApp />
+      </Suspense>
+    );
+  }
+
+  return (
+    // Le build public VPS expose uniquement les pages utiles après scan QR ou
+    // connexion. Les routes de jeu restent disponibles dans `FlipperApp`.
+    <PublicApp />
   );
 }
 

--- a/frontend/src/FlipperApp.tsx
+++ b/frontend/src/FlipperApp.tsx
@@ -1,0 +1,36 @@
+import { Route, Routes } from "react-router-dom";
+
+import AuthGuard from "./components/auth/AuthGuard";
+import { MqttProvider } from "./mqtt/mqttContext";
+import Backglass from "./pages/Backglass";
+import Dashboard from "./pages/Dashboard";
+import DMD from "./pages/DMD";
+import Home from "./pages/Home";
+import Login from "./pages/Login";
+import Playfield from "./pages/Playfield";
+import ScoreClaim from "./pages/ScoreClaim";
+
+export default function FlipperApp() {
+  return (
+    // Le provider MQTT est réservé au flipper local. Le VPS public ne doit pas
+    // ouvrir de WebSocket MQTT depuis une page HTTPS.
+    <MqttProvider>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/score-claim" element={<ScoreClaim />} />
+        <Route path="/playfield" element={<Playfield />} />
+        <Route
+          path="/dashboard"
+          element={
+            <AuthGuard>
+              <Dashboard />
+            </AuthGuard>
+          }
+        />
+        <Route path="/backglass" element={<Backglass />} />
+        <Route path="/dmd" element={<DMD />} />
+      </Routes>
+    </MqttProvider>
+  );
+}

--- a/frontend/src/components/pinball/Ball.tsx
+++ b/frontend/src/components/pinball/Ball.tsx
@@ -12,12 +12,16 @@ import { useGameDebug } from "@/config/useGameDebug";
 import { useControls, folder, button } from "leva";
 
 type BallProps = {
-  id: string;
-  origin: "launcher" | "cannon";
+  id?: string;
+  origin?: "launcher" | "cannon";
   position: [number, number, number];
 };
 
-export default function Ball({ id, origin, position }: BallProps) {
+export default function Ball({
+  id = "legacy_launcher_ball",
+  origin = "launcher",
+  position,
+}: BallProps) {
   const ballRef = useRef<RapierRigidBody>(null);
 
   const [launchCount, setLaunchCount] = useState(0);

--- a/frontend/src/components/pinball/Bumper.tsx
+++ b/frontend/src/components/pinball/Bumper.tsx
@@ -3,7 +3,7 @@ import {
   type RapierRigidBody,
   type CollisionEnterPayload,
 } from "@react-three/rapier";
-import { useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import { useGameStore } from "@/store/gameStore/useGameStore";
@@ -15,7 +15,13 @@ import { SCORE_VALUES } from "@/config/gameBalancingConfig";
 type BumperProps = {
   id: 0 | 1 | 2;
   colliderGeometry: THREE.BufferGeometry;
-  visualNode: React.ReactNode;
+  // Nouveau modèle : le parent peut fournir directement un node prêt à rendre.
+  visualNode?: ReactNode;
+  // Ancien modèle : certains fichiers MVP passent encore une géométrie et un
+  // matériau séparés. Cette compatibilité permet de garder le build stable le
+  // temps que les modèles soient harmonisés.
+  visualGeometry?: THREE.BufferGeometry;
+  visualMaterial?: THREE.Material;
   rubyGeometry: THREE.BufferGeometry;
   rubyMaterial: THREE.Material;
   position: [number, number, number];
@@ -30,6 +36,8 @@ export default function Bumper({
   id,
   colliderGeometry,
   visualNode,
+  visualGeometry,
+  visualMaterial,
   rubyGeometry,
   rubyMaterial,
   position,
@@ -98,8 +106,13 @@ export default function Bumper({
         <meshBasicMaterial transparent opacity={0} />
       </mesh>
 
-      {/* Enveloppe le visuel fourni dans un groupe pour l'animer */}
-      <group ref={visualGroupRef}>{visualNode}</group>
+      {/* Enveloppe le visuel fourni dans un groupe pour l'animer. */}
+      <group ref={visualGroupRef}>
+        {visualNode ??
+          (visualGeometry && visualMaterial ? (
+            <mesh geometry={visualGeometry} material={visualMaterial} />
+          ) : null)}
+      </group>
 
       <mesh
         scale={isRubyActive ? 1 : 0}

--- a/frontend/src/components/score-claim/BackglassScoreClaimPanel.tsx
+++ b/frontend/src/components/score-claim/BackglassScoreClaimPanel.tsx
@@ -1,0 +1,100 @@
+import { getScoreClaimDescription, getScoreClaimPhaseLabel } from "../../lib/score-claim-copy";
+import type {
+  ScoreClaimSessionPhase,
+  ScoreClaimSessionSnapshot,
+} from "../../lib/score-claim-session-store";
+import ScoreClaimQrCode from "./ScoreClaimQrCode";
+
+type BackglassScoreClaimPanelProps = {
+  className?: string;
+  snapshot: ScoreClaimSessionSnapshot;
+};
+
+const visibleBackglassPhases: ScoreClaimSessionPhase[] = [
+  "submitting",
+  "claim_pending",
+  "claim_approved",
+  "claim_expired",
+  "error",
+];
+
+function formatScore(score: number) {
+  return new Intl.NumberFormat("fr-FR").format(score);
+}
+
+export function shouldShowBackglassScoreClaimPanel(
+  snapshot: ScoreClaimSessionSnapshot,
+) {
+  return visibleBackglassPhases.includes(snapshot.phase);
+}
+
+export default function BackglassScoreClaimPanel({
+  className = "",
+  snapshot,
+}: BackglassScoreClaimPanelProps) {
+  if (!shouldShowBackglassScoreClaimPanel(snapshot)) {
+    return null;
+  }
+
+  const verificationUrl =
+    snapshot.phase === "claim_pending"
+      ? snapshot.claim?.verificationUrl
+      : null;
+
+  return (
+    <aside
+      className={`rounded-2xl border border-amber-400/30 bg-black/80 p-4 text-sm text-white shadow-lg backdrop-blur ${className}`}
+    >
+      {/* Ce composant est volontairement autonome : le futur Backglass pourra
+          le placer où il veut sans reprendre la logique score-claim. */}
+      <p className="text-xs uppercase tracking-[0.25em] text-amber-300">
+        Score final
+      </p>
+
+      <h2 className="mt-2 text-xl font-bold text-white">
+        {getScoreClaimPhaseLabel(snapshot.phase)}
+      </h2>
+
+      <p className="mt-2 text-slate-300">
+        {getScoreClaimDescription(snapshot)}
+      </p>
+
+      {snapshot.game && (
+        <p className="mt-4 rounded-lg bg-white/10 px-3 py-2 font-semibold text-amber-100">
+          Score : {formatScore(snapshot.game.finalScore)}
+        </p>
+      )}
+
+      {verificationUrl && (
+        <div className="mt-4 flex flex-col items-center rounded-xl border border-amber-400/20 bg-stone-950/90 p-4">
+          <div className="rounded-xl bg-amber-50 p-2 shadow-[0_0_22px_rgba(251,191,36,0.28)]">
+            <ScoreClaimQrCode verificationUrl={verificationUrl} />
+          </div>
+          <p className="mt-3 text-center text-xs text-slate-300">
+            Scannez, connectez-vous, puis confirmez le score.
+          </p>
+        </div>
+      )}
+
+      {snapshot.phase === "claim_approved" && (
+        <p className="mt-4 rounded-lg border border-emerald-300/30 bg-emerald-950/60 px-3 py-2 text-emerald-100">
+          {snapshot.user?.username
+            ? `Rattaché à ${snapshot.user.username}`
+            : "Score rattaché au compte joueur."}
+        </p>
+      )}
+
+      {snapshot.phase === "claim_expired" && (
+        <p className="mt-4 rounded-lg border border-orange-300/30 bg-orange-950/60 px-3 py-2 text-orange-100">
+          Relancez une partie pour générer un nouveau QR code.
+        </p>
+      )}
+
+      {snapshot.errorMessage && (
+        <p className="mt-4 rounded-lg border border-red-300/30 bg-red-950/60 px-3 py-2 text-red-100">
+          {snapshot.errorMessage}
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/hooks/useScoreClaim.ts
+++ b/frontend/src/hooks/useScoreClaim.ts
@@ -42,56 +42,69 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isApproving, setIsApproving] = useState(false);
 
-  useEffect(() => {
+  async function loadScoreClaim({
+    clearFeedback = true,
+    signal,
+    showLoading = true,
+  }: {
+    clearFeedback?: boolean;
+    signal?: AbortSignal;
+    showLoading?: boolean;
+  } = {}) {
     if (!claimCode) {
       setStatus("idle");
       setClaim(null);
       return;
     }
 
+    try {
+      if (showLoading) {
+        setStatus("loading");
+      }
+
+      if (clearFeedback) {
+        setFeedback(null);
+      }
+
+      const response = await fetch(
+        apiEndpoint(`/api/score-claims/status/${claimCode}`),
+        {
+          signal,
+        },
+      );
+
+      if (response.status === 404) {
+        setStatus("not_found");
+        return;
+      }
+
+      if (response.status === 410) {
+        setStatus("expired");
+        return;
+      }
+
+      if (!response.ok) {
+        setStatus("error");
+        return;
+      }
+
+      const payload = (await response.json()) as ScoreClaimPayload;
+      setClaim(payload);
+      setStatus(payload.status);
+    } catch (error) {
+      if (!signal?.aborted) {
+        console.error("Score claim lookup failed:", error);
+        setStatus("error");
+      }
+    }
+  }
+
+  useEffect(() => {
     // Ce hook charge l'état d'une demande de claim déjà créée côté borne.
     // Il sert aussi à lancer l'approbation finale depuis le téléphone.
     const abortController = new AbortController();
 
-    async function fetchScoreClaim() {
-      try {
-        setStatus("loading");
-        setFeedback(null);
-
-        const response = await fetch(
-          apiEndpoint(`/api/score-claims/status/${claimCode}`),
-          {
-            signal: abortController.signal,
-          },
-        );
-
-        if (response.status === 404) {
-          setStatus("not_found");
-          return;
-        }
-
-        if (response.status === 410) {
-          setStatus("expired");
-          return;
-        }
-
-        if (!response.ok) {
-          setStatus("error");
-          return;
-        }
-
-        const payload = (await response.json()) as ScoreClaimPayload;
-        setClaim(payload);
-        setStatus(payload.status);
-      } catch (error) {
-        if (!abortController.signal.aborted) {
-          console.error("Score claim lookup failed:", error);
-          setStatus("error");
-        }
-      }
-    }
-
-    void fetchScoreClaim();
+    void loadScoreClaim({ signal: abortController.signal });
 
     return () => {
       abortController.abort();
@@ -150,6 +163,10 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
       );
       setStatus("approved");
       setFeedback("Le score a bien été rattaché à votre compte.");
+
+      // On relit immédiatement le statut complet pour afficher le compte
+      // rattaché sans obliger l'utilisateur à rafraîchir la page mobile.
+      await loadScoreClaim({ clearFeedback: false, showLoading: false });
     } finally {
       setIsApproving(false);
     }

--- a/frontend/src/hooks/useScoreClaimSession.ts
+++ b/frontend/src/hooks/useScoreClaimSession.ts
@@ -99,7 +99,7 @@ export function useScoreClaimSession({
         if (!response.ok) {
           const nextSnapshot = stampSnapshot({
             ...snapshot,
-            errorMessage: "Impossible de récupérer le statut du claim.",
+            errorMessage: "QR CODE EXPIRÉ",
             phase: "error",
           });
           setSnapshot(nextSnapshot);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,13 +1,70 @@
 function resolveApiUrl() {
-  if (import.meta.env.VITE_API_URL) {
-    return import.meta.env.VITE_API_URL;
+  const configuredApiUrl = import.meta.env.VITE_API_URL?.trim();
+
+  if (shouldUseSameOriginApi(configuredApiUrl)) {
+    return resolveSameOriginApiUrl();
+  }
+
+  if (configuredApiUrl) {
+    return configuredApiUrl;
   }
 
   if (typeof window !== "undefined") {
-    return `${window.location.protocol}//${window.location.hostname}:3000`;
+    return resolveSameOriginApiUrl();
   }
 
   return "http://localhost:3000";
+}
+
+function resolveSameOriginApiUrl() {
+  const location = window.location;
+
+  if (location.origin) {
+    return location.origin;
+  }
+
+  // Certains environnements de test ne fournissent pas `location.origin`.
+  // On reconstruit donc l'origine minimale à partir des champs standards.
+  const port = location.port ? `:${location.port}` : "";
+  return `${location.protocol}//${location.hostname}${port}`;
+}
+
+function isLoopbackApiUrl(value: string) {
+  try {
+    const { hostname } = new URL(value);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseSameOriginApi(configuredApiUrl: string | undefined) {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (import.meta.env.VITE_APP_TARGET === "public") {
+    // Le build public tourne sur le VPS derrière Nginx. Si aucune API n'est
+    // configurée, ou si une ancienne config injecte `localhost`, on appelle la
+    // même origine pour éviter que le téléphone cherche son propre port 3000.
+    return !configuredApiUrl || isLoopbackApiUrl(configuredApiUrl);
+  }
+
+  if (import.meta.env.VITE_APP_TARGET !== "flipper") {
+    return false;
+  }
+
+  // En dev Vite, le frontend tourne sur 5173 et le backend sur 3000 : on garde
+  // donc l'URL explicite. En production borne, on ignore volontairement
+  // `VITE_API_URL` côté navigateur : le frontend appelle sa propre origine et
+  // Nginx relaie `/api` vers le backend Docker interne. Cela évite qu'une
+  // variable injectée par l'outil de déploiement fasse pointer Chrome vers un
+  // `localhost:3000` inaccessible ou une API distante non voulue.
+  if (window.location.port === "5173") {
+    return false;
+  }
+
+  return true;
 }
 
 export const apiUrl = resolveApiUrl();

--- a/frontend/src/lib/app-target.ts
+++ b/frontend/src/lib/app-target.ts
@@ -1,0 +1,18 @@
+export type AppTarget = "flipper" | "public";
+
+export function parseAppTarget(value: string | null | undefined): AppTarget {
+  // Le build `flipper` reste le comportement par défaut : il charge le jeu,
+  // MQTT, les écrans DMD/backglass et les routes de borne locale.
+  if (value === "public") {
+    return "public";
+  }
+
+  return "flipper";
+}
+
+export const appTarget = parseAppTarget(import.meta.env.VITE_APP_TARGET);
+
+// Ces constantes centralisent le découpage entre le flipper physique et le VPS.
+// Elles évitent de disperser des comparaisons de variables Vite dans les pages.
+export const isPublicAppTarget = appTarget === "public";
+export const isFlipperAppTarget = appTarget === "flipper";

--- a/frontend/src/lib/score-claim-copy.ts
+++ b/frontend/src/lib/score-claim-copy.ts
@@ -5,19 +5,19 @@ export function getScoreClaimPhaseLabel(phase: ScoreClaimSessionPhase) {
     case "idle":
       return "Prêt";
     case "submitting":
-      return "Sauvegarde du score";
+      return "Préparation du QR code";
     case "discarded":
-      return "Score ignoré";
+      return "Score non enregistré";
     case "saved":
-      return "Score sauvegardé";
+      return "Score enregistré";
     case "claim_pending":
-      return "En attente de scan";
+      return "Scannez le QR code";
     case "claim_approved":
-      return "Score rattaché";
+      return "Score enregistré";
     case "claim_expired":
-      return "Claim expiré";
+      return "QR code expiré";
     case "error":
-      return "Erreur";
+      return "QR code indisponible";
   }
 }
 
@@ -38,27 +38,27 @@ export function getScoreClaimDmdMessage(snapshot: ScoreClaimSessionSnapshot) {
     case "claim_expired":
       return "CLAIM EXPIRED";
     case "error":
-      return "CLAIM ERROR";
+      return "";
   }
 }
 
 export function getScoreClaimDescription(snapshot: ScoreClaimSessionSnapshot) {
   switch (snapshot.phase) {
     case "idle":
-      return "Lancez une fin de partie technique pour tester le flux.";
+      return "Le QR code apparaîtra à la fin de la partie.";
     case "submitting":
-      return "La borne enregistre le score final et évalue s'il doit être claimable.";
+      return "Sauvegarde du score en cours...";
     case "discarded":
-      return "Le backend a décidé de ne pas conserver ce score.";
+      return "Ce score n'a pas été conservé.";
     case "saved":
-      return "Le score est conservé, mais aucun rattachement mobile n'est proposé.";
+      return "Le score est enregistré.";
     case "claim_pending":
-      return "Le score est sauvegardé et attend une confirmation explicite sur le téléphone.";
+      return "Scannez avec votre téléphone pour rattacher le score.";
     case "claim_approved":
-      return "Le score est désormais rattaché à un compte joueur.";
+      return "Le score est rattaché à un compte joueur.";
     case "claim_expired":
-      return "La fenêtre de rattachement est terminée.";
+      return "Ce QR code n'est plus utilisable.";
     case "error":
-      return snapshot.errorMessage ?? "Le flux de claim a échoué.";
+      return snapshot.errorMessage ?? "Impossible d'afficher le QR code pour le moment.";
   }
 }

--- a/frontend/src/lib/score-claim-gameover.ts
+++ b/frontend/src/lib/score-claim-gameover.ts
@@ -1,0 +1,77 @@
+// Le service backend refuse les claims invités trop courts afin d'éviter les
+// faux scores générés par erreur. Cette constante garde le front aligné avec
+// cette règle métier au moment de créer automatiquement le QR code.
+const MIN_SIGNIFICANT_CLAIM_DURATION_SECONDS = 20;
+
+// Les scores sont stockés dans des colonnes integer côté Postgres. On borne
+// donc la valeur envoyée pour éviter une erreur SQL si le jeu dépasse ce seuil.
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+
+export type GameOverScoreClaimInput = {
+  finalScore: number;
+  playedDurationSeconds: number;
+  requestClaim: boolean;
+};
+
+type CreateGameOverScoreClaimInputOptions = {
+  endedAtMs: number;
+  scores: number[];
+  startedAtMs: number | null;
+};
+
+function normalizeScore(score: number) {
+  if (!Number.isFinite(score)) {
+    return 0;
+  }
+
+  return Math.min(POSTGRES_INTEGER_MAX, Math.max(0, Math.trunc(score)));
+}
+
+export function getFinalScoreForClaim(scores: number[]) {
+  if (scores.length === 0) {
+    return 0;
+  }
+
+  return Math.max(...scores.map(normalizeScore));
+}
+
+export function getPlayedDurationSecondsForClaim(
+  startedAtMs: number | null,
+  endedAtMs: number,
+  finalScore: number,
+) {
+  const measuredDurationSeconds =
+    startedAtMs === null
+      ? 0
+      : Math.max(0, Math.ceil((endedAtMs - startedAtMs) / 1000));
+
+  // Le backend ignore les scores invités trop courts. On conserve donc la
+  // durée mesurée, mais on applique le minimum métier quand un score positif
+  // existe afin que les tests borne très rapides puissent générer un QR code.
+  if (finalScore > 0) {
+    return Math.max(
+      MIN_SIGNIFICANT_CLAIM_DURATION_SECONDS,
+      measuredDurationSeconds,
+    );
+  }
+
+  return measuredDurationSeconds;
+}
+
+export function createGameOverScoreClaimInput({
+  endedAtMs,
+  scores,
+  startedAtMs,
+}: CreateGameOverScoreClaimInputOptions): GameOverScoreClaimInput {
+  const finalScore = getFinalScoreForClaim(scores);
+
+  return {
+    finalScore,
+    playedDurationSeconds: getPlayedDurationSecondsForClaim(
+      startedAtMs,
+      endedAtMs,
+      finalScore,
+    ),
+    requestClaim: true,
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,14 +3,11 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.tsx";
-import { MqttProvider } from "./mqtt/mqttContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
   // <StrictMode>
   <BrowserRouter>
-    <MqttProvider>
-      <App />
-    </MqttProvider>
+    <App />
   </BrowserRouter>,
   //</StrictMode>
 );

--- a/frontend/src/pages/Playfield.tsx
+++ b/frontend/src/pages/Playfield.tsx
@@ -1,64 +1,94 @@
-import { useEffect, Suspense } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
-import { Physics } from "@react-three/rapier";
-import { Perf } from "r3f-perf";
 import { Environment } from "@react-three/drei";
-import { Leva } from "leva";
 import {
-  EffectComposer,
   Bloom,
+  EffectComposer,
   ToneMapping,
 } from "@react-three/postprocessing";
+import { Physics } from "@react-three/rapier";
 import { ToneMappingMode } from "postprocessing";
-import ScoreClaimControlPanel from "../components/score-claim/ScoreClaimControlPanel";
-import Experience from "../experience/Experience";
-import Loader from "../components/utils/Loader";
-import { useAppMode } from "../hooks/useAppMode";
-import { useScoreClaimSession } from "../hooks/useScoreClaimSession";
-import { useKeyboardControls } from "../mqtt/useKeyboardControls";
+import { Perf } from "r3f-perf";
+import { Leva } from "leva";
+
+import Loader from "@/components/utils/Loader";
+import { useGameDebug } from "@/config/useGameDebug";
+import Experience from "@/experience/Experience";
+import { useAppMode } from "@/hooks/useAppMode";
+import { useScoreClaimSession } from "@/hooks/useScoreClaimSession";
+import { createGameOverScoreClaimInput } from "@/lib/score-claim-gameover";
+import { useKeyboardControls } from "@/mqtt/useKeyboardControls";
 import { useGameStore } from "@/store/gameStore/useGameStore";
 import { useInputStore } from "@/store/inputStore/useInputStore";
-import { useGameDebug } from "@/config/useGameDebug";
 
 export default function Playfield() {
   const { isArcadeMode, mode } = useAppMode();
-  const {
-    authenticatedUser,
-    isSessionPending,
-    resetScoreClaimSession,
-    snapshot,
-    startScoreClaimSession,
-  } = useScoreClaimSession({ enabled: isArcadeMode, mode });
+  const { resetScoreClaimSession, startScoreClaimSession } =
+    useScoreClaimSession({ enabled: isArcadeMode, mode });
+  const { gravity, perfVisible, rapierDebug } = useGameDebug();
 
   useKeyboardControls();
 
   const startPressed = useInputStore((state) => state.buttons.start);
-  const isPlaying = useGameStore((state) => state.isPlaying);
-  const startGame = useGameStore((state) => state.startGame);
   const updateInputs = useInputStore((state) => state.updateInputs);
+  const isPlaying = useGameStore((state) => state.isPlaying);
+  const scores = useGameStore((state) => state.scores);
+  const startGame = useGameStore((state) => state.startGame);
+
+  // Ces refs detectent les transitions de partie sans provoquer de re-render.
+  // Elles evitent surtout de creer plusieurs claims pour le meme game over.
+  const wasPlayingRef = useRef(isPlaying);
+  const gameStartedAtRef = useRef<number | null>(isPlaying ? Date.now() : null);
+  const submittedGameOverKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (startPressed && !isPlaying) {
-      console.log("🎮 Démarrage de la partie depuis MQTT / Bouton Start !");
+      console.log("Demarrage de la partie depuis MQTT / Bouton Start.");
       startGame(1);
       updateInputs({ buttons: { start: false } });
     }
   }, [startPressed, isPlaying, startGame, updateInputs]);
 
-  const { rapierDebug, gravity, perfVisible } = useGameDebug();
+  useEffect(() => {
+    const wasPlaying = wasPlayingRef.current;
+
+    if (isPlaying && !wasPlaying) {
+      gameStartedAtRef.current = Date.now();
+      submittedGameOverKeyRef.current = null;
+      // Une nouvelle partie doit retirer l'ancien QR code du backglass.
+      resetScoreClaimSession();
+    }
+
+    if (isArcadeMode && wasPlaying && !isPlaying) {
+      const endedAtMs = Date.now();
+      // Le score envoye au backend vient du store reel alimente par addScore,
+      // pas d'un champ de test saisi manuellement dans l'interface.
+      const scoreClaimInput = createGameOverScoreClaimInput({
+        endedAtMs,
+        scores,
+        startedAtMs: gameStartedAtRef.current,
+      });
+      const gameOverKey = `${gameStartedAtRef.current ?? "unknown"}:${scores.join(
+        "-",
+      )}`;
+
+      if (submittedGameOverKeyRef.current !== gameOverKey) {
+        submittedGameOverKeyRef.current = gameOverKey;
+        void startScoreClaimSession(scoreClaimInput);
+      }
+    }
+
+    wasPlayingRef.current = isPlaying;
+  }, [
+    isArcadeMode,
+    isPlaying,
+    resetScoreClaimSession,
+    scores,
+    startScoreClaimSession,
+  ]);
 
   return (
     <div className="relative h-screen w-screen">
-      {isArcadeMode && (
-        <ScoreClaimControlPanel
-          authenticatedUser={authenticatedUser}
-          isSessionPending={isSessionPending}
-          onReset={resetScoreClaimSession}
-          onStart={startScoreClaimSession}
-          snapshot={snapshot}
-        />
-      )}
-
       <Leva collapsed />
       <Suspense fallback={<Loader />}>
         <Canvas shadows camera={{ position: [0, 8, 15], fov: 50 }}>
@@ -73,12 +103,11 @@ export default function Playfield() {
           </Physics>
           <EffectComposer>
             <Bloom
-              luminanceThreshold={2} // Seuil minimal pour pour le bloom (isole l'épée du plateau)
-              luminanceSmoothing={0} // Empêche la diffusion du bloom sur les autres objets (plateau, personnages) pour éviter un effet brouillard
-              mipmapBlur // Utilise un flou basé sur les mipmaps pour un bloom plus naturel
               intensity={1.2}
+              luminanceSmoothing={0}
+              luminanceThreshold={2}
+              mipmapBlur
             />
-            {/* Attribution du Tone Maping pour des couleurs intenses */}
             <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
           </EffectComposer>
         </Canvas>

--- a/frontend/src/pages/ScoreClaim.tsx
+++ b/frontend/src/pages/ScoreClaim.tsx
@@ -24,14 +24,20 @@ export default function ScoreClaim() {
   const { approveScoreClaim, claim, feedback, isApproving, status } = useScoreClaim({
     claimCode,
   });
+  const approvedAccountLabel =
+    claim?.user?.username ??
+    session?.user.username ??
+    session?.user.email ??
+    "votre compte";
 
   if (!claimCode) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-xl flex-col justify-center px-6">
         <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h1 className="text-2xl font-semibold">Code QR invalide</h1>
+          <h1 className="text-2xl font-semibold">Aucun score à rattacher</h1>
           <p className="mt-3 text-sm text-slate-500">
-            La demande de rattachement ne contient pas de code de claim.
+            Cette page fonctionne uniquement après le scan d'un QR code généré
+            par le flipper en fin de partie.
           </p>
           <Link className="mt-6 inline-block text-blue-600" to={withMode("/")}>
             Retour à l'accueil
@@ -110,15 +116,18 @@ export default function ScoreClaim() {
                   onClick={approveScoreClaim}
                   type="button"
                 >
-                  {isApproving ? "Association..." : "Associer ce score à mon compte"}
+                  {isApproving ? "Enregistrement..." : "Enregistrer mon score"}
                 </button>
               </div>
             )}
 
             {status === "approved" && (
-              <p className="rounded bg-slate-100 px-3 py-2 text-sm text-slate-700">
-                Ce score est déjà rattaché à un compte.
-              </p>
+              <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-900">
+                <p className="font-semibold">Score enregistré.</p>
+                <p className="mt-1">
+                  Ce score est rattaché à {approvedAccountLabel}.
+                </p>
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/store/inputStore/useInputStore.ts
+++ b/frontend/src/store/inputStore/useInputStore.ts
@@ -3,6 +3,12 @@ import { create } from "zustand";
 // Interface représentant la structure du JSON du topic MQTT "pinball/input/state"
 export interface InputState {
   buttons: {
+    // Actions métier consommées par le playfield.
+    // Elles sont dérivées des boutons physiques pour garder les composants 3D
+    // indépendants du câblage exact de la borne.
+    start: boolean;
+    launch_ball: boolean;
+
     black_left: boolean;
     white_left: boolean;
     front_left_green: boolean;
@@ -33,6 +39,8 @@ interface InputStore extends InputState {
 export const useInputStore = create<InputStore>((set) => ({
   // Valeurs initiales par défaut conformes au JSON MQTT
   buttons: {
+    start: false,
+    launch_ball: false,
     black_left: false,
     white_left: false,
     front_left_green: false,
@@ -47,16 +55,37 @@ export const useInputStore = create<InputStore>((set) => ({
     nudge: { x: 0, y: 0, z: 9.81 },
   },
   updateInputs: (payload) =>
-    set((state) => ({
-      buttons: { ...state.buttons, ...payload.buttons },
-      analog: {
-        plunger:
-          payload.analog?.plunger !== undefined
-            ? payload.analog.plunger
-            : state.analog.plunger,
-        nudge: payload.analog?.nudge
-          ? { ...state.analog.nudge, ...payload.analog.nudge }
-          : state.analog.nudge,
-      },
-    })),
+    set((state) => {
+      const incomingButtons = payload.buttons ?? {};
+      const buttons = { ...state.buttons, ...incomingButtons };
+
+      // Mapping actuel validé avec le firmware/mock MQTT :
+      // black_left démarre la partie, front_white déclenche le lanceur.
+      if (
+        incomingButtons.black_left !== undefined &&
+        incomingButtons.start === undefined
+      ) {
+        buttons.start = incomingButtons.black_left;
+      }
+
+      if (
+        incomingButtons.front_white !== undefined &&
+        incomingButtons.launch_ball === undefined
+      ) {
+        buttons.launch_ball = incomingButtons.front_white;
+      }
+
+      return {
+        buttons,
+        analog: {
+          plunger:
+            payload.analog?.plunger !== undefined
+              ? payload.analog.plunger
+              : state.analog.plunger,
+          nudge: payload.analog?.nudge
+            ? { ...state.analog.nudge, ...payload.analog.nudge }
+            : state.analog.nudge,
+        },
+      };
+    }),
 }));

--- a/frontend/src/tests/api.test.ts
+++ b/frontend/src/tests/api.test.ts
@@ -28,15 +28,96 @@ describe("api", () => {
     vi.stubGlobal("window", {
       location: {
         hostname: "frontend.pinball.test",
+        origin: "https://frontend.pinball.test",
         protocol: "https:",
       },
     });
 
     const { apiEndpoint, apiUrl } = await importApi();
 
-    expect(apiUrl).toBe("https://frontend.pinball.test:3000");
+    expect(apiUrl).toBe("https://frontend.pinball.test");
     expect(apiEndpoint("/auth/session")).toBe(
-      "https://frontend.pinball.test:3000/auth/session",
+      "https://frontend.pinball.test/auth/session",
+    );
+  });
+
+  it("utilise l'origine du frontend en production flipper avec le fallback localhost", async () => {
+    vi.stubEnv("VITE_APP_TARGET", "flipper");
+    vi.stubEnv("VITE_API_URL", "http://localhost:3000");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "localhost",
+        origin: "http://localhost",
+        port: "",
+        protocol: "http:",
+      },
+    });
+
+    const { apiEndpoint, apiUrl } = await importApi();
+
+    expect(apiUrl).toBe("http://localhost");
+    expect(apiEndpoint("/api/score-claims/start")).toBe(
+      "http://localhost/api/score-claims/start",
+    );
+  });
+
+  it("ignore VITE_API_URL en production flipper pour passer par Nginx", async () => {
+    vi.stubEnv("VITE_APP_TARGET", "flipper");
+    vi.stubEnv("VITE_API_URL", "https://pinball.dev-christopher.fr");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "localhost",
+        origin: "http://localhost",
+        port: "",
+        protocol: "http:",
+      },
+    });
+
+    const { apiEndpoint, apiUrl } = await importApi();
+
+    expect(apiUrl).toBe("http://localhost");
+    expect(apiEndpoint("/api/score-claims/start")).toBe(
+      "http://localhost/api/score-claims/start",
+    );
+  });
+
+  it("ignore un fallback localhost dans le build public VPS", async () => {
+    vi.stubEnv("VITE_APP_TARGET", "public");
+    vi.stubEnv("VITE_API_URL", "http://localhost:3000");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "pinball.dev-christopher.fr",
+        origin: "https://pinball.dev-christopher.fr",
+        port: "",
+        protocol: "https:",
+      },
+    });
+
+    const { apiEndpoint, apiUrl } = await importApi();
+
+    expect(apiUrl).toBe("https://pinball.dev-christopher.fr");
+    expect(apiEndpoint("/api/score-claims/start")).toBe(
+      "https://pinball.dev-christopher.fr/api/score-claims/start",
+    );
+  });
+
+  it("conserve l'URL backend explicite pendant le dev Vite", async () => {
+    vi.stubEnv("VITE_APP_TARGET", "flipper");
+    vi.stubEnv("VITE_API_URL", "http://localhost:3000");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "localhost",
+        origin: "http://localhost:5173",
+        port: "5173",
+        protocol: "http:",
+      },
+    });
+
+    const { apiEndpoint, apiUrl } = await importApi();
+
+    expect(apiUrl).toBe("http://localhost:3000");
+    expect(apiEndpoint("/api/score-claims/start")).toBe(
+      "http://localhost:3000/api/score-claims/start",
     );
   });
 

--- a/frontend/src/tests/app-target.test.ts
+++ b/frontend/src/tests/app-target.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAppTarget } from "../lib/app-target";
+
+describe("app-target", () => {
+  it("utilise le build flipper par defaut", () => {
+    expect(parseAppTarget(undefined)).toBe("flipper");
+    expect(parseAppTarget(null)).toBe("flipper");
+    expect(parseAppTarget("unknown")).toBe("flipper");
+  });
+
+  it("active explicitement le build public", () => {
+    expect(parseAppTarget("public")).toBe("public");
+  });
+});

--- a/frontend/src/tests/score-claim.test.ts
+++ b/frontend/src/tests/score-claim.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getScoreClaimDescription,
+  getScoreClaimDmdMessage,
+  getScoreClaimPhaseLabel,
+} from "../lib/score-claim-copy";
+import {
+  createGameOverScoreClaimInput,
+  getFinalScoreForClaim,
+  getPlayedDurationSecondsForClaim,
+} from "../lib/score-claim-gameover";
+import {
+  clearScoreClaimSessionSnapshot,
+  createIdleScoreClaimSessionSnapshot,
+  readScoreClaimSessionSnapshot,
+  subscribeToScoreClaimSessionSnapshot,
+  type ScoreClaimSessionPhase,
+  type ScoreClaimSessionSnapshot,
+  writeScoreClaimSessionSnapshot,
+} from "../lib/score-claim-session-store";
+
+const phaseExpectations: Array<{
+  phase: ScoreClaimSessionPhase;
+  label: string;
+  dmdMessage: string;
+  description: string;
+}> = [
+  {
+    phase: "idle",
+    label: "Prêt",
+    dmdMessage: "GAME OVER",
+    description: "Le QR code apparaîtra à la fin de la partie.",
+  },
+  {
+    phase: "submitting",
+    label: "Préparation du QR code",
+    dmdMessage: "SAVING SCORE",
+    description: "Sauvegarde du score en cours...",
+  },
+  {
+    phase: "discarded",
+    label: "Score non enregistré",
+    dmdMessage: "SCORE NOT SAVED",
+    description: "Ce score n'a pas été conservé.",
+  },
+  {
+    phase: "saved",
+    label: "Score enregistré",
+    dmdMessage: "SCORE SAVED",
+    description: "Le score est enregistré.",
+  },
+  {
+    phase: "claim_pending",
+    label: "Scannez le QR code",
+    dmdMessage: "SCAN TO CLAIM",
+    description: "Scannez avec votre téléphone pour rattacher le score.",
+  },
+  {
+    phase: "claim_approved",
+    label: "Score enregistré",
+    dmdMessage: "SCORE LINKED",
+    description: "Le score est rattaché à un compte joueur.",
+  },
+  {
+    phase: "claim_expired",
+    label: "QR code expiré",
+    dmdMessage: "CLAIM EXPIRED",
+    description: "Ce QR code n'est plus utilisable.",
+  },
+  {
+    phase: "error",
+    label: "QR code indisponible",
+    dmdMessage: "",
+    description: "Impossible d'afficher le QR code pour le moment.",
+  },
+];
+
+function snapshotForPhase(
+  phase: ScoreClaimSessionPhase,
+  input: Partial<ScoreClaimSessionSnapshot> = {},
+): ScoreClaimSessionSnapshot {
+  return {
+    ...createIdleScoreClaimSessionSnapshot(),
+    ...input,
+    phase,
+  };
+}
+
+describe("score-claim copy", () => {
+  it("fournit des libellés stables pour chaque phase du claim", () => {
+    for (const expectation of phaseExpectations) {
+      const snapshot = snapshotForPhase(expectation.phase);
+
+      expect(getScoreClaimPhaseLabel(expectation.phase)).toBe(
+        expectation.label,
+      );
+      expect(getScoreClaimDmdMessage(snapshot)).toBe(expectation.dmdMessage);
+      expect(getScoreClaimDescription(snapshot)).toBe(
+        expectation.description,
+      );
+    }
+  });
+
+  it("affiche le détail d'erreur quand le backend en fournit un", () => {
+    const snapshot = snapshotForPhase("error", {
+      errorMessage: "Le VPS ne répond pas.",
+    });
+
+    expect(getScoreClaimDescription(snapshot)).toBe("Le VPS ne répond pas.");
+  });
+});
+
+describe("score-claim session store", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it("crée un snapshot idle explicite quand aucune session n'existe", () => {
+    expect(readScoreClaimSessionSnapshot()).toEqual(
+      createIdleScoreClaimSessionSnapshot(),
+    );
+  });
+
+  it("écrit, relit et efface la session partagée entre les écrans", () => {
+    const listener = vi.fn();
+    window.addEventListener("pinball:score-claim-session-updated", listener);
+
+    const snapshot = snapshotForPhase("claim_pending", {
+      claim: {
+        claimCode: "ABC123",
+        expiresAt: "2026-01-01T12:00:00.000Z",
+        status: "pending",
+        verificationUrl: "https://pinball.example/claim/ABC123",
+      },
+      decision: "save_and_claimable",
+      game: {
+        finalScore: 120_000,
+        id: 10,
+        playedAt: "2026-01-01T12:00:00.000Z",
+        playedDurationSeconds: 180,
+      },
+      updatedAt: "2026-01-01T12:00:00.000Z",
+    });
+
+    writeScoreClaimSessionSnapshot(snapshot);
+    expect(readScoreClaimSessionSnapshot()).toEqual(snapshot);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    clearScoreClaimSessionSnapshot();
+    expect(readScoreClaimSessionSnapshot()).toEqual(
+      createIdleScoreClaimSessionSnapshot(),
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    window.removeEventListener("pinball:score-claim-session-updated", listener);
+  });
+
+  it("notifie les abonnés sur événement local et événement storage", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToScoreClaimSessionSnapshot(listener);
+
+    writeScoreClaimSessionSnapshot(snapshotForPhase("saved"));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "pinball.score-claim-session",
+      }),
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "autre-cle",
+      }),
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    clearScoreClaimSessionSnapshot();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("retombe sur idle quand la session persistée est illisible", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    window.localStorage.setItem("pinball.score-claim-session", "{invalid-json");
+
+    expect(readScoreClaimSessionSnapshot()).toEqual(
+      createIdleScoreClaimSessionSnapshot(),
+    );
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("reste sans effet côté rendu serveur où window n'existe pas", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(readScoreClaimSessionSnapshot()).toEqual(
+      createIdleScoreClaimSessionSnapshot(),
+    );
+    expect(() =>
+      writeScoreClaimSessionSnapshot(snapshotForPhase("saved")),
+    ).not.toThrow();
+    expect(() => clearScoreClaimSessionSnapshot()).not.toThrow();
+
+    const unsubscribe = subscribeToScoreClaimSessionSnapshot(vi.fn());
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+describe("score-claim game over input", () => {
+  it("utilise le meilleur score réel de la partie", () => {
+    expect(getFinalScoreForClaim([12_000, 98_500, 42_000])).toBe(98_500);
+  });
+
+  it("normalise les scores invalides avant envoi au backend", () => {
+    expect(getFinalScoreForClaim([Number.NaN, -50, 12.9])).toBe(12);
+  });
+
+  it("applique la durée minimale métier pour un score positif très court", () => {
+    expect(getPlayedDurationSecondsForClaim(1_000, 3_500, 10_000)).toBe(20);
+  });
+
+  it("conserve la durée réelle quand elle dépasse le minimum", () => {
+    expect(getPlayedDurationSecondsForClaim(1_000, 35_100, 10_000)).toBe(35);
+  });
+
+  it("prépare le payload automatique de fin de partie", () => {
+    expect(
+      createGameOverScoreClaimInput({
+        endedAtMs: 31_000,
+        scores: [1_000, 25_000],
+        startedAtMs: 1_000,
+      }),
+    ).toEqual({
+      finalScore: 25_000,
+      playedDurationSeconds: 30,
+      requestClaim: true,
+    });
+  });
+});

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_APP_TARGET?: "flipper" | "public";
   readonly VITE_API_URL?: string;
+  readonly VITE_MQTT_PASSWORD?: string;
+  readonly VITE_MQTT_URL?: string;
+  readonly VITE_MQTT_USERNAME?: string;
 }
 
 interface ImportMeta {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
@@ -9,32 +9,40 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
-    coverage: {
-      provider: 'v8',
-      thresholds: {
-        lines: 80,
-        functions: 80,
-        branches: 80,
-        statements: 80,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, __dirname, "");
+  const appTarget = env.VITE_APP_TARGET === "public" ? "public" : "flipper";
+
+  return {
+    // Le build public VPS ne doit pas embarquer les assets physiques du flipper
+    // situes dans `public/` (modeles 3D, sons, textures lourdes).
+    publicDir: appTarget === "public" ? false : "public",
+    plugins: [react(), tailwindcss()],
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./vitest.setup.ts'],
+      coverage: {
+        provider: 'v8',
+        thresholds: {
+          lines: 80,
+          functions: 80,
+          branches: 80,
+          statements: 80,
+        },
       },
     },
-  },
-  server: {
-    host: true,
-    port: 5173,
-    watch: {
-      usePolling: true,
+    server: {
+      host: true,
+      port: 5173,
+      watch: {
+        usePolling: true,
+      },
     },
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
+  };
 });


### PR DESCRIPTION
Mise en place de l’architecture VPS dédiée au rattachement des scores.

Cette PR ajoute le déploiement VPS public, la génération du QR code après une demande du back-end local, la page mobile de rattachement de score, ainsi que l’enregistrement sécurisé des scores dans la base PostgreSQL du VPS.

Points principaux :
- ajout du mode `remote` côté borne/flipper pour envoyer les demandes de score au VPS ;
- ajout du mode `local` côté VPS pour enregistrer les scores en base ;
- sécurisation des appels borne vers VPS avec `BORNE_TOKEN` ;
- séparation du front public VPS avec `VITE_APP_TARGET=public`  afin d'éviter de créer des pages différentes;
- ajout du `docker-compose.vps.yml` et de la documentation de déploiement du VPS ;
- mise à jour de la CI pour tester le front-end et le back-end.