### PR TITLE
fix: fiabiliser le score claim mobile et le portail VPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - completed
     branches:
       - main
+      - fix/#123-score-claim-mobile-auth-vps
 
 
 jobs:

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,6 +1,7 @@
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { betterAuth } from "better-auth";
 import { username } from "better-auth/plugins";
+import { eq } from "drizzle-orm";
 
 import { getDb, type DatabaseClient } from "./db/client.js";
 import * as schema from "./db/schema.js";
@@ -13,6 +14,173 @@ type CreateAuthDependencies = {
   db: DatabaseClient;
   env: AuthEnv;
 };
+
+type AuthUserCreationData = {
+  displayUsername?: string | null;
+  email?: string;
+  name?: string | null;
+  username?: string | null;
+} & Record<string, unknown>;
+
+const USERNAME_MIN_LENGTH = 3;
+const USERNAME_MAX_LENGTH = 30;
+const DEFAULT_USERNAME_BASE = "joueur";
+
+function getNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue ? trimmedValue : null;
+}
+
+function removeDiacritics(value: string) {
+  return Array.from(value.normalize("NFD"))
+    .filter((character) => character < "\u0300" || character > "\u036f")
+    .join("");
+}
+
+function isUsernameLetterOrDigit(character: string) {
+  const code = character.charCodeAt(0);
+  const isDigit = code >= 48 && code <= 57;
+  const isLowercaseLetter = code >= 97 && code <= 122;
+
+  return isDigit || isLowercaseLetter;
+}
+
+function trimUsernameSeparators(value: string) {
+  let startIndex = 0;
+  let endIndex = value.length;
+
+  while (startIndex < endIndex && isUsernameSeparator(value[startIndex] ?? "")) {
+    startIndex += 1;
+  }
+
+  while (endIndex > startIndex && isUsernameSeparator(value[endIndex - 1] ?? "")) {
+    endIndex -= 1;
+  }
+
+  return value.slice(startIndex, endIndex);
+}
+
+function isUsernameSeparator(character: string) {
+  return character === "-" || character === "_";
+}
+
+function cropUsername(value: string) {
+  return trimUsernameSeparators(value.slice(0, USERNAME_MAX_LENGTH));
+}
+
+export function normalizeUsernameCandidate(value: string) {
+  const normalizedValue = removeDiacritics(value).toLowerCase();
+  let nextUsername = "";
+  let previousWasSeparator = false;
+
+  for (const character of normalizedValue) {
+    if (isUsernameLetterOrDigit(character)) {
+      nextUsername += character;
+      previousWasSeparator = false;
+      continue;
+    }
+
+    if (!previousWasSeparator && nextUsername.length > 0) {
+      nextUsername += "-";
+      previousWasSeparator = true;
+    }
+  }
+
+  const croppedUsername = cropUsername(nextUsername);
+
+  if (croppedUsername.length >= USERNAME_MIN_LENGTH) {
+    return croppedUsername;
+  }
+
+  return DEFAULT_USERNAME_BASE;
+}
+
+function getEmailLocalPart(email: string | null) {
+  if (!email) {
+    return null;
+  }
+
+  const atIndex = email.indexOf("@");
+  return atIndex > 0 ? email.slice(0, atIndex) : email;
+}
+
+export function createUsernameBaseFromUser(user: AuthUserCreationData) {
+  const preferredValue =
+    getNonEmptyString(user.username) ??
+    getNonEmptyString(user.displayUsername) ??
+    getNonEmptyString(user.name) ??
+    getEmailLocalPart(getNonEmptyString(user.email)) ??
+    DEFAULT_USERNAME_BASE;
+
+  return normalizeUsernameCandidate(preferredValue);
+}
+
+function createUsernameCandidate(baseUsername: string, suffix: number) {
+  if (suffix === 0) {
+    return cropUsername(baseUsername);
+  }
+
+  const suffixText = `-${suffix}`;
+  const baseMaxLength = USERNAME_MAX_LENGTH - suffixText.length;
+  return `${cropUsername(baseUsername.slice(0, baseMaxLength))}${suffixText}`;
+}
+
+async function isUsernameAvailable(db: DatabaseClient, usernameCandidate: string) {
+  const existingUsers = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.username, usernameCandidate))
+    .limit(1);
+
+  return existingUsers.length === 0;
+}
+
+async function createAvailableUsername(db: DatabaseClient, baseUsername: string) {
+  for (let suffix = 0; suffix < 100; suffix += 1) {
+    const usernameCandidate = createUsernameCandidate(baseUsername, suffix);
+
+    if (await isUsernameAvailable(db, usernameCandidate)) {
+      return usernameCandidate;
+    }
+  }
+
+  // Cas très improbable : trop de collisions sur le même nom. On garde un
+  // suffixe temporel lisible au lieu de bloquer complètement l'inscription.
+  return createUsernameCandidate(baseUsername, Date.now());
+}
+
+async function createNormalizedUserData(db: DatabaseClient, user: AuthUserCreationData) {
+  const currentUsername = getNonEmptyString(user.username);
+  const currentDisplayUsername = getNonEmptyString(user.displayUsername);
+  const currentName = getNonEmptyString(user.name);
+
+  if (currentUsername && currentDisplayUsername && currentName) {
+    return undefined;
+  }
+
+  const usernameValue = currentUsername
+    ? normalizeUsernameCandidate(currentUsername)
+    : await createAvailableUsername(db, createUsernameBaseFromUser(user));
+  const shouldInitializeOAuthIdentity = !currentUsername;
+
+  return {
+    data: {
+      ...user,
+      // Pour les comptes OAuth, Better Auth peut créer un utilisateur sans
+      // username. On initialise les champs visibles avec la même valeur simple
+      // afin que le dashboard et le score claim restent exploitables.
+      displayUsername: shouldInitializeOAuthIdentity
+        ? usernameValue
+        : currentDisplayUsername ?? usernameValue,
+      name: shouldInitializeOAuthIdentity ? usernameValue : currentName ?? usernameValue,
+      username: usernameValue,
+    },
+  };
+}
 
 function createSocialProviders(authEnv: AuthEnv) {
   // On garde un objet typé pour éviter un typage trop permissif
@@ -94,6 +262,14 @@ export function createAuth({
       autoSignIn: true,
       minPasswordLength: 8,
       requireEmailVerification: false,
+    },
+
+    databaseHooks: {
+      user: {
+        create: {
+          before: async (user) => createNormalizedUserData(db, user),
+        },
+      },
     },
 
     socialProviders: createSocialProviders(env),

--- a/backend/tests/unit/auth.test.ts
+++ b/backend/tests/unit/auth.test.ts
@@ -44,7 +44,11 @@ vi.mock("../../src/env.js", () => ({
   env: mocks.env,
 }));
 
-import { createAuth } from "../../src/auth.js";
+import {
+  createAuth,
+  createUsernameBaseFromUser,
+  normalizeUsernameCandidate,
+} from "../../src/auth.js";
 
 function buildAuthEnv(
   overrides: Partial<{
@@ -150,6 +154,152 @@ describe("auth configuration", () => {
       maxUsernameLength: 30,
       minUsernameLength: 3,
     });
+  });
+
+  it("normalizes missing OAuth profile fields before user creation", async () => {
+    const limitMock = vi.fn(async () => []);
+    const whereMock = vi.fn(() => ({ limit: limitMock }));
+    const fromMock = vi.fn(() => ({ where: whereMock }));
+    const selectMock = vi.fn(() => ({ from: fromMock }));
+
+    createAuth({
+      db: { select: selectMock } as never,
+      env: buildAuthEnv() as never,
+    });
+
+    const options = mocks.betterAuth.mock.calls.at(-1)?.[0] as {
+      databaseHooks: {
+        user: {
+          create: {
+            before: (
+              user: {
+                displayUsername?: string | null;
+                email?: string | null;
+                name?: string | null;
+                username?: string | null;
+              },
+              context: null,
+            ) => Promise<{
+              data: {
+                displayUsername: string;
+                name: string;
+                username: string;
+              };
+            }>;
+          };
+        };
+      };
+    };
+
+    const result = await options.databaseHooks.user.create.before(
+      {
+        email: "christopher@example.test",
+        name: "Christopher De Pasqual",
+      },
+      null,
+    );
+
+    expect(result.data).toMatchObject({
+      displayUsername: "christopher-de-pasqual",
+      name: "christopher-de-pasqual",
+      username: "christopher-de-pasqual",
+    });
+    expect(selectMock).toHaveBeenCalled();
+  });
+
+  it("normalizes a readable username candidate from profile values", () => {
+    expect(normalizeUsernameCandidate("Élodie Dragon Slayer !!!")).toBe(
+      "elodie-dragon-slayer",
+    );
+    expect(normalizeUsernameCandidate("ab")).toBe("joueur");
+    expect(createUsernameBaseFromUser({
+      email: "Player.One+Arcade@example.test",
+    })).toBe("player-one-arcade");
+    expect(createUsernameBaseFromUser({})).toBe("joueur");
+  });
+
+  it("uses a numbered suffix when the generated OAuth username is already taken", async () => {
+    const limitMock = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "existing-user" }])
+      .mockResolvedValueOnce([]);
+    const whereMock = vi.fn(() => ({ limit: limitMock }));
+    const fromMock = vi.fn(() => ({ where: whereMock }));
+    const selectMock = vi.fn(() => ({ from: fromMock }));
+
+    createAuth({
+      db: { select: selectMock } as never,
+      env: buildAuthEnv() as never,
+    });
+
+    const options = mocks.betterAuth.mock.calls.at(-1)?.[0] as {
+      databaseHooks: {
+        user: {
+          create: {
+            before: (
+              user: {
+                email?: string | null;
+                name?: string | null;
+                username?: string | null;
+              },
+              context: null,
+            ) => Promise<{
+              data: {
+                username: string;
+              };
+            }>;
+          };
+        };
+      };
+    };
+
+    const result = await options.databaseHooks.user.create.before(
+      {
+        email: "taken@example.test",
+        name: "Taken",
+      },
+      null,
+    );
+
+    expect(result.data.username).toBe("taken-1");
+    expect(limitMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves complete user profiles unchanged", async () => {
+    createAuth({
+      db: { kind: "test-db" } as never,
+      env: buildAuthEnv() as never,
+    });
+
+    const options = mocks.betterAuth.mock.calls.at(-1)?.[0] as {
+      databaseHooks: {
+        user: {
+          create: {
+            before: (
+              user: {
+                displayUsername?: string | null;
+                email?: string | null;
+                name?: string | null;
+                username?: string | null;
+              },
+              context: null,
+            ) => Promise<unknown>;
+          };
+        };
+      };
+    };
+
+    await expect(
+      options.databaseHooks.user.create.before(
+        {
+          displayUsername: "alice",
+          email: "alice@example.test",
+          name: "Alice",
+          username: "alice",
+        },
+        null,
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("logs a success message when Better Auth initialization completes", () => {

--- a/frontend/src/components/dmd/dungeonDragonDmd.config.ts
+++ b/frontend/src/components/dmd/dungeonDragonDmd.config.ts
@@ -54,7 +54,7 @@ export const LIVE_LAYOUT = {
     centerY: 29,
   },
   score: {
-    centerX: 110,
+    centerX: 96,
     eventMaxWidth: 96,
     eventPreferredScale: 2,
     eventY: 4,

--- a/frontend/src/hooks/useScoreClaim.ts
+++ b/frontend/src/hooks/useScoreClaim.ts
@@ -44,10 +44,12 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
 
   async function loadScoreClaim({
     clearFeedback = true,
+    preserveCurrentStateOnError = false,
     signal,
     showLoading = true,
   }: {
     clearFeedback?: boolean;
+    preserveCurrentStateOnError?: boolean;
     signal?: AbortSignal;
     showLoading?: boolean;
   } = {}) {
@@ -74,17 +76,23 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
       );
 
       if (response.status === 404) {
-        setStatus("not_found");
+        if (!preserveCurrentStateOnError) {
+          setStatus("not_found");
+        }
         return;
       }
 
       if (response.status === 410) {
-        setStatus("expired");
+        if (!preserveCurrentStateOnError) {
+          setStatus("expired");
+        }
         return;
       }
 
       if (!response.ok) {
-        setStatus("error");
+        if (!preserveCurrentStateOnError) {
+          setStatus("error");
+        }
         return;
       }
 
@@ -94,7 +102,9 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
     } catch (error) {
       if (!signal?.aborted) {
         console.error("Score claim lookup failed:", error);
-        setStatus("error");
+        if (!preserveCurrentStateOnError) {
+          setStatus("error");
+        }
       }
     }
   }
@@ -156,6 +166,7 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
         currentClaim
           ? {
               ...currentClaim,
+              approvedAt: currentClaim.approvedAt ?? new Date().toISOString(),
               game: payload.game,
               status: payload.status,
             }
@@ -165,8 +176,13 @@ export function useScoreClaim({ claimCode }: UseScoreClaimOptions) {
       setFeedback("Le score a bien été rattaché à votre compte.");
 
       // On relit immédiatement le statut complet pour afficher le compte
-      // rattaché sans obliger l'utilisateur à rafraîchir la page mobile.
-      await loadScoreClaim({ clearFeedback: false, showLoading: false });
+      // rattaché. Si cette relecture échoue sur mobile, on conserve quand même
+      // l'écran confirmé car l'approbation backend a déjà réussi.
+      await loadScoreClaim({
+        clearFeedback: false,
+        preserveCurrentStateOnError: true,
+        showLoading: false,
+      });
     } finally {
       setIsApproving(false);
     }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useAppMode } from "../hooks/useAppMode";
+import { isFlipperAppTarget } from "../lib/app-target";
 import { authClient, signOut, useSession } from "../lib/auth-client";
 
 type ProfileValues = {
@@ -521,9 +522,11 @@ export default function Dashboard() {
           <Link className="text-blue-600" to={withMode("/")}>
             Retour à l'accueil
           </Link>
-          <Link className="text-blue-600" to={withMode("/playfield")}>
-            Ouvrir le Playfield
-          </Link>
+          {isFlipperAppTarget && (
+            <Link className="text-blue-600" to={withMode("/playfield")}>
+              Ouvrir le Playfield
+            </Link>
+          )}
         </div>
       </section>
     </main>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,32 +1,53 @@
 import { Link } from "react-router-dom";
 
 import { useAppMode } from "../hooks/useAppMode";
+import { isPublicAppTarget } from "../lib/app-target";
 import { signOut, useSession } from "../lib/auth-client";
+
+type HomeLink = {
+  label: string;
+  path: string;
+};
+
+export function getHomeLinks(isPublicTarget = isPublicAppTarget): HomeLink[] {
+  const publicLinks: HomeLink[] = [
+    { label: "Login", path: "/login" },
+    { label: "Dashboard", path: "/dashboard" },
+  ];
+
+  if (isPublicTarget) {
+    return publicLinks;
+  }
+
+  // Ces écrans appartiennent au build flipper local. On ne les expose pas
+  // sur le portail VPS pour éviter des liens cassés ou inutiles côté mobile.
+  return [
+    ...publicLinks,
+    { label: "Playfield", path: "/playfield" },
+    { label: "Backglass", path: "/backglass" },
+    { label: "DMD", path: "/dmd" },
+  ];
+}
 
 export default function Home() {
   const { data: session, isPending } = useSession();
   const { withMode } = useAppMode();
+  const homeLinks = getHomeLinks();
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center justify-center gap-6 px-6">
       <h2 className="text-3xl font-semibold">Pinball Three.js</h2>
 
       <div className="flex flex-wrap items-center justify-center gap-4">
-        <Link className="hover:text-blue-600" to={withMode("/login")}>
-          Login
-        </Link>
-        <Link className="hover:text-blue-600" to={withMode("/dashboard")}>
-          Dashboard
-        </Link>
-        <Link className="hover:text-blue-600" to={withMode("/playfield")}>
-          Playfield
-        </Link>
-        <Link className="hover:text-blue-600" to={withMode("/backglass")}>
-          Backglass
-        </Link>
-        <Link className="hover:text-blue-600" to={withMode("/dmd")}>
-          DMD
-        </Link>
+        {homeLinks.map((link) => (
+          <Link
+            className="hover:text-blue-600"
+            key={link.path}
+            to={withMode(link.path)}
+          >
+            {link.label}
+          </Link>
+        ))}
       </div>
       <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm">
         {isPending && <p>Chargement de la session...</p>}

--- a/frontend/src/tests/Home.test.tsx
+++ b/frontend/src/tests/Home.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import Home from "../pages/Home";
+import Home, { getHomeLinks } from "../pages/Home";
 
 const { signOutMock, useSessionMock, withModeMock } = vi.hoisted(() => ({
   signOutMock: vi.fn(),
@@ -51,6 +51,23 @@ describe("Page Home", () => {
     renderWithRouter(<Home />);
 
     expect(screen.getByText("Pinball Three.js")).toBeInTheDocument();
+  });
+
+  it("limite les liens d'accueil au portail public quand le build cible le VPS", () => {
+    expect(getHomeLinks(true)).toEqual([
+      { label: "Login", path: "/login" },
+      { label: "Dashboard", path: "/dashboard" },
+    ]);
+  });
+
+  it("conserve les liens flipper uniquement pour le build local de la borne", () => {
+    expect(getHomeLinks(false).map((link) => link.path)).toEqual([
+      "/login",
+      "/dashboard",
+      "/playfield",
+      "/backglass",
+      "/dmd",
+    ]);
   });
 
   it("affiche l'etat de chargement de session", () => {

--- a/frontend/src/tests/useScoreClaim.test.tsx
+++ b/frontend/src/tests/useScoreClaim.test.tsx
@@ -1,0 +1,139 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useScoreClaim } from "../hooks/useScoreClaim";
+
+const pendingClaimPayload = {
+  approvedAt: null,
+  expiresAt: "2026-07-03T12:00:00.000Z",
+  game: {
+    finalScore: 123_456,
+    id: 12,
+    playedAt: "2026-07-03T11:55:00.000Z",
+    playedDurationSeconds: 95,
+  },
+  status: "pending" as const,
+  user: null,
+};
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status,
+  });
+}
+
+describe("useScoreClaim", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reste idle et ne contacte pas l'API sans code de claim", () => {
+    const { result } = renderHook(() => useScoreClaim({ claimCode: "" }));
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.claim).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { expectedStatus: "not_found", httpStatus: 404 },
+    { expectedStatus: "expired", httpStatus: 410 },
+    { expectedStatus: "error", httpStatus: 500 },
+  ] as const)(
+    "expose le statut $expectedStatus quand le chargement répond $httpStatus",
+    async ({ expectedStatus, httpStatus }) => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: httpStatus }));
+
+      const { result } = renderHook(() =>
+        useScoreClaim({ claimCode: "CLAIM-CODE" }),
+      );
+
+      await waitFor(() => expect(result.current.status).toBe(expectedStatus));
+    },
+  );
+
+  it("conserve la confirmation mobile si la relecture du claim échoue après approbation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(pendingClaimPayload))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          game: {
+            ...pendingClaimPayload.game,
+            finalScore: 130_000,
+          },
+          status: "approved",
+        }),
+      )
+      .mockRejectedValueOnce(new Error("temporary network failure"));
+
+    const { result } = renderHook(() =>
+      useScoreClaim({ claimCode: "CLAIM-CODE" }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("pending"));
+
+    await act(async () => {
+      await result.current.approveScoreClaim();
+    });
+
+    expect(result.current.status).toBe("approved");
+    expect(result.current.claim).toMatchObject({
+      game: {
+        finalScore: 130_000,
+      },
+      status: "approved",
+    });
+    expect(result.current.feedback).toBe(
+      "Le score a bien été rattaché à votre compte.",
+    );
+  });
+
+  it.each([
+    {
+      expectedFeedback: "Cette demande n'existe plus.",
+      expectedStatus: "not_found",
+      httpStatus: 404,
+    },
+    {
+      expectedFeedback: "Le délai pour rattacher ce score est expiré.",
+      expectedStatus: "expired",
+      httpStatus: 410,
+    },
+    {
+      expectedFeedback: "claim already approved elsewhere",
+      expectedStatus: "pending",
+      httpStatus: 409,
+      payload: { error: "claim already approved elsewhere" },
+    },
+  ] as const)(
+    "gère proprement une approbation refusée avec le statut $httpStatus",
+    async ({ expectedFeedback, expectedStatus, httpStatus, payload }) => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(pendingClaimPayload))
+        .mockResolvedValueOnce(jsonResponse(payload ?? {}, httpStatus));
+
+      const { result } = renderHook(() =>
+        useScoreClaim({ claimCode: "CLAIM-CODE" }),
+      );
+
+      await waitFor(() => expect(result.current.status).toBe("pending"));
+
+      await act(async () => {
+        await result.current.approveScoreClaim();
+      });
+
+      expect(result.current.status).toBe(expectedStatus);
+      expect(result.current.feedback).toBe(expectedFeedback);
+    },
+  );
+});


### PR DESCRIPTION
## Objectif

Corriger le parcours de rattachement de score sur mobile et clarifier le portail public VPS.

## Changements

- Limite l’accueil du build VPS public aux pages utiles : Login et Dashboard.
- Masque le lien Playfield dans le Dashboard lorsque l’application est buildée pour le VPS.
- Fiabilise la confirmation mobile du score claim après validation, même si la relecture réseau échoue juste après.
- Initialise automatiquement `username`, `displayUsername` et `name` pour les comptes OAuth sans nom utilisateur.
- Ajoute des tests frontend/backend sur ces comportements.

## Vérifications

- `pnpm --dir frontend test`
- `pnpm --dir backend test`
- `pnpm --dir frontend build`
- `pnpm --dir backend build`
- `pnpm --dir frontend coverage`
- `pnpm --dir backend coverage`